### PR TITLE
Improve `coloredlogs` installation

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -28,10 +28,8 @@ version_files = ["pyproject.toml:version"]
 
 # https://python-poetry.org/docs/dependency-specification/
 [tool.poetry.dependencies]
-{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-coloredlogs = "^15.0.1"
-{%- endif %}
 {%- if cookiecutter.with_fastapi_api|int %}
+coloredlogs = "^15.0.1"
 fastapi = "^0.70.1"
 gunicorn = "^20.1.0"
 {%- endif %}

--- a/{{ cookiecutter.package_name|slugify }}/src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py
+++ b/{{ cookiecutter.package_name|slugify }}/src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py
@@ -1,19 +1,1 @@
 """{{ cookiecutter.package_name }} package."""
-{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-
-import logging
-
-import coloredlogs
-
-
-def configure_root_logger() -> None:
-    """Configure the root logger."""
-    # Remove all handlers associated with the root logger object.
-    for handler in logging.root.handlers:
-        logging.root.removeHandler(handler)
-    # Add coloredlogs' coloured StreamHandler to the root logger.
-    coloredlogs.install()
-
-
-configure_root_logger()
-{%- endif %}

--- a/{{ cookiecutter.package_name|slugify }}/src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/{% if cookiecutter.with_fastapi_api|int %}api.py{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/{% if cookiecutter.with_fastapi_api|int %}api.py{% endif %}
@@ -9,7 +9,7 @@ app = FastAPI()
 
 
 @app.on_event("startup")
-def startup_event():
+def startup_event() -> None:
     """Run API startup events."""
     # Remove all handlers associated with the root logger object.
     for handler in logging.root.handlers:

--- a/{{ cookiecutter.package_name|slugify }}/src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/{% if cookiecutter.with_fastapi_api|int %}api.py{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/{% if cookiecutter.with_fastapi_api|int %}api.py{% endif %}
@@ -1,8 +1,21 @@
 """{{ cookiecutter.package_name }} REST API."""
 
+import logging
+
+import coloredlogs
 from fastapi import FastAPI
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def startup_event():
+    """Run API startup events."""
+    # Remove all handlers associated with the root logger object.
+    for handler in logging.root.handlers:
+        logging.root.removeHandler(handler)
+    # Add coloredlogs' coloured StreamHandler to the root logger.
+    coloredlogs.install()
 
 
 @app.get("/")


### PR DESCRIPTION
- [x] Best practice: no code in `__init__.py` (except export definitions).
- [x] Best practice: don't run code on importing a package (now runs on API startup event).
- `coloredlogs` is no longer available by default for Streamlit, but the benefit there isn't as big as with FastAPI.