### PR TITLE
Improve Docker networking

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -92,9 +92,6 @@ COPY . .
 
 # Expose the application.
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-ARG PORT=8000
-ENV PORT $PORT
-EXPOSE $PORT
 ENTRYPOINT ["/usr/local/bin/poe"]
 CMD [{% if cookiecutter.with_fastapi_api|int %}"serve"{% else %}"streamlit"{% endif %}]
 {%- else %}

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -12,6 +12,8 @@ services:
         {%- endif %}
       context: .
       target: dev
+    tty: true
+    entrypoint: []
     command:
       [
         "sh",
@@ -21,8 +23,11 @@ services:
     environment:
       - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
+    hostname: "{{ cookiecutter.package_name|slugify }}-dev.local"
     ports:
-      - "8000:8000"
+      - "8000"
+    expose:
+      - "8000"
     {%- endif %}
     volumes:
       # app
@@ -44,9 +49,13 @@ services:
         {%- endif %}
       context: .
       target: app
+    tty: true
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
+    hostname: "{{ cookiecutter.package_name|slugify }}.local"
     ports:
-      - "8000:8000"
+      - "8000"
+    expose:
+      - "8000"
     {%- endif %}
     profiles:
       - app

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -234,7 +234,7 @@ testpaths = "tests"
   [tool.poe.tasks.serve]
   help = "Serve a REST API in production"
   cmd = """
-    gunicorn 
+    gunicorn
       --access-logfile -
       --bind 0.0.0.0:$port
       --graceful-timeout 10


### PR DESCRIPTION
- [x] Add a hostname so you can easily access the service in the browser with the address `{package-slug}.local`.
- [x] Dynamically bind the container port to an available post on the host. Closes #21.
- [x] Expose the container's port to other containers with `expose`.
- [x] Adds `tty: true` for coloured output (default is false).