### PR TITLE
fix: Use `coverage_report` instead of `cobertura`

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -92,7 +92,9 @@ Test:
   coverage: '/^TOTAL.*\s+(\d+\%)$/'
   artifacts:
     reports:
-      cobertura: reports/coverage.xml
+      coverage_report: 
+        coverage_format: cobertura
+        path: reports/coverage.xml
       junit:
         - reports/mypy.xml
         - reports/pytest.xml


### PR DESCRIPTION
This broke on GitLab CI for some reason. The new allowed property is
described on:

https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscoverage_report