### PR TITLE
feat: use build and run time secrets

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.package_name|slugify }}/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Python environment
         run: |
           {%- if cookiecutter.private_package_repository_name %}
-          poetry config http-basic.{{ cookiecutter.private_package_repository_name }} "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME }}" "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD }}"
+          poetry config http-basic.{{ cookiecutter.private_package_repository_name|slugify }} "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_USERNAME }}" "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_PASSWORD }}"
           {%- endif %}
           poetry config virtualenvs.in-project true
           poetry install --no-interaction

--- a/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}deploy.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}deploy.yml{% endif %}
@@ -55,8 +55,10 @@ jobs:
           push: true
           {%- if cookiecutter.private_package_repository_name %}
           secrets: |
-            poetry-http-basic-username={% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME }}
-            poetry-http-basic-password={% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD }}
+            "poetry_auth=[http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]
+            username = ""{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_USERNAME }}""
+            password = ""{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_PASSWORD }}""
+            "
           {%- endif %}
           tags: |
             {% raw %}${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ github.repository }}:${{ github.event.inputs.environment || env.DEFAULT_DEPLOYMENT_ENVIRONMENT }}{% endraw %}

--- a/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if not cookiecutter.with_fastapi_api|int and not cookiecutter.with_streamlit_app|int %}publish.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if not cookiecutter.with_fastapi_api|int and not cookiecutter.with_streamlit_app|int %}publish.yml{% endif %}
@@ -27,10 +27,10 @@ jobs:
       - name: Publish package
         run: |
           {%- if cookiecutter.private_package_repository_name %}
-          poetry config repositories.private "{{ cookiecutter.private_package_repository_url.replace('simple', '') }}"
-          poetry config http-basic.private "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME }}" "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD }}"
+          poetry config repositories.private "{{ cookiecutter.private_package_repository_url.replace('simple/', '').replace('simple', '') }}"
+          poetry config http-basic.private "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_USERNAME }}" "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_PASSWORD }}"
           poetry publish --build --repository private
           {%- else %}
-          poetry config http-basic.pypi "__token__" "{% raw %}${{ secrets.POETRY_PYPI_TOKEN_PYPI }}{% endraw %}"
+          poetry config pypi-token.pypi "{% raw %}${{ secrets.POETRY_PYPI_TOKEN_PYPI }}{% endraw %}"
           poetry publish --build
           {%- endif %}

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -29,18 +29,6 @@ RUN --mount=type=cache,target=/root/.cache/ \
     curl -sSL https://install.python-poetry.org | python - --version $POETRY_VERSION && \
     poetry config virtualenvs.create false
 
-# Enable Poetry to publish to {% if cookiecutter.private_package_repository_name %}and install from a private package repository{% else %}PyPI{% endif %} [1].
-# [1] https://pythonspeed.com/articles/build-secrets-docker-compose/
-{%- if cookiecutter.private_package_repository_name %}
-ARG POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
-ENV POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
-ARG POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
-ENV POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
-{%- else %}
-ARG POETRY_PYPI_TOKEN_PYPI
-ENV POETRY_PYPI_TOKEN_PYPI $POETRY_PYPI_TOKEN_PYPI
-{%- endif %}
-
 # Let Poe the Poet know it doesn't need to activate the Python environment.
 ENV POETRY_ACTIVE 1
 
@@ -53,14 +41,9 @@ FROM base as dev
 COPY .pre-commit-config.yaml poetry.lock* pyproject.toml /app/
 RUN --mount=type=cache,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
-    --mount=type=secret,id=poetry-http-basic-username \
-    --mount=type=secret,id=poetry-http-basic-password \
+    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
     {%- endif %}
     mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
-    {%- if cookiecutter.private_package_repository_name %}
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME=${POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME:-$(cat /run/secrets/poetry-http-basic-username)} \
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD=${POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD:-$(cat /run/secrets/poetry-http-basic-password)} \
-    {%- endif %}
     poetry install --no-interaction && \
     mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
     git init && pre-commit install --install-hooks && \
@@ -73,14 +56,9 @@ FROM base as ci
 COPY poetry.lock pyproject.toml /app/
 RUN --mount=type=cache,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
-    --mount=type=secret,id=poetry-http-basic-username \
-    --mount=type=secret,id=poetry-http-basic-password \
+    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
     {%- endif %}
     mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
-    {%- if cookiecutter.private_package_repository_name %}
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME=${POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME:-$(cat /run/secrets/poetry-http-basic-username)} \
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD=${POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD:-$(cat /run/secrets/poetry-http-basic-password)} \
-    {%- endif %}
     poetry install --no-dev --no-interaction
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
 

--- a/{{ cookiecutter.package_name|slugify }}/README.md
+++ b/{{ cookiecutter.package_name|slugify }}/README.md
@@ -44,7 +44,7 @@ To add and install this package as a dependency of your project, run `poetry add
     POETRY_AUTH_TOML_PATH=~/.config/pypoetry/auth.toml
 
     # macOS
-    POETRY_AUTH_TOML_PATH=~/Library/Application Support/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH=~/Library/Application\ Support/pypoetry/auth.toml
 
     # Windows
     POETRY_AUTH_TOML_PATH=$APPDATA/pypoetry/auth.toml
@@ -77,7 +77,7 @@ To add and install this package as a dependency of your project, run `poetry add
     POETRY_AUTH_TOML_PATH=~/.config/pypoetry/auth.toml
 
     # macOS
-    POETRY_AUTH_TOML_PATH=~/Library/Application Support/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH=~/Library/Application\ Support/pypoetry/auth.toml
 
     # Windows
     POETRY_AUTH_TOML_PATH=$APPDATA/pypoetry/auth.toml

--- a/{{ cookiecutter.package_name|slugify }}/README.md
+++ b/{{ cookiecutter.package_name|slugify }}/README.md
@@ -41,13 +41,13 @@ To add and install this package as a dependency of your project, run `poetry add
 1. Create a `.env` file in the project directory that [Docker Compose reads](https://docs.docker.com/compose/env-file/) to pass Poetry's `auth.toml` file as a [build and run time secret](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets-configuration-reference):
     ```sh
     # Linux
-    POETRY_AUTH_TOML_PATH=~/.config/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH="~/.config/pypoetry/auth.toml"
 
     # macOS
-    POETRY_AUTH_TOML_PATH=~/Library/Application\ Support/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH="~/Library/Application Support/pypoetry/auth.toml"
 
     # Windows
-    POETRY_AUTH_TOML_PATH=$APPDATA/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH="$APPDATA/pypoetry/auth.toml"
     ```
 {%- endif %}
 {%- else -%}
@@ -74,19 +74,21 @@ To add and install this package as a dependency of your project, run `poetry add
 1. Create a `.env` file in the project directory that [Docker Compose reads](https://docs.docker.com/compose/env-file/) to pass Poetry's `auth.toml` file as a [build and run time secret](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets-configuration-reference):
     ```sh
     # Linux
-    POETRY_AUTH_TOML_PATH=~/.config/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH="~/.config/pypoetry/auth.toml"
 
     # macOS
-    POETRY_AUTH_TOML_PATH=~/Library/Application\ Support/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH="~/Library/Application Support/pypoetry/auth.toml"
 
     # Windows
-    POETRY_AUTH_TOML_PATH=$APPDATA/pypoetry/auth.toml
+    POETRY_AUTH_TOML_PATH="$APPDATA/pypoetry/auth.toml"
     ```
 {%- endif %}
 {%- endif %}
-1. [Install Docker Desktop](https://www.docker.com/get-started). If you are using Linux, you must [configure Docker and Docker Compose to use the BuildKit build system](https://pythonspeed.com/articles/docker-buildkit/). On macOS and Windows, BuildKit is enabled by default in Docker Desktop.
+1. [Install Docker Desktop](https://www.docker.com/get-started).
+  - Open Docker Desktop's preferences window and enable _Use Docker Compose V2_.
+  - If you are using Linux, you must [configure Docker and Docker Compose to use the BuildKit build system](https://pythonspeed.com/articles/docker-buildkit/). On macOS and Windows, BuildKit is enabled by default in Docker Desktop.
 1. [Install VS Code](https://code.visualstudio.com/) and [VS Code's Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Alternatively, install [PyCharm](https://www.jetbrains.com/pycharm/download/).
-1. _Optional:_ [Install FiraCode Nerd Font](https://www.nerdfonts.com/font-downloads) with `brew tap homebrew/cask-fonts && brew install --cask font-fira-code-nerd-font` and [configure VS Code](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions) or [configure PyCharm](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions) to use `'FiraCode Nerd Font'`.
+  - _Optional:_ [Install FiraCode Nerd Font](https://www.nerdfonts.com/font-downloads) with `brew tap homebrew/cask-fonts && brew install --cask font-fira-code-nerd-font` and [configure VS Code](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions) or [configure PyCharm](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions) to use `'FiraCode Nerd Font'`.
 
 </details>
 

--- a/{{ cookiecutter.package_name|slugify }}/README.md
+++ b/{{ cookiecutter.package_name|slugify }}/README.md
@@ -29,19 +29,25 @@ To add and install this package as a dependency of your project, run `poetry add
     EOF
     ```
 {%- if cookiecutter.private_package_repository_name %}
-1. [Create a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) with the `api` scope and use it to [configure Poetry's credentials for this package's private repository](https://python-poetry.org/docs/repositories/#configuring-credentials):
+1. [Create a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) with the `api` scope and use it to [add your private package repository credentials to your Poetry's `auth.toml` file](https://python-poetry.org/docs/repositories/#configuring-credentials):
+    ```toml
+    # Linux:   ~/.config/pypoetry/auth.toml
+    # macOS:   ~/Library/Application Support/pypoetry/auth.toml
+    # Windows: C:\Users\%USERNAME%\AppData\Roaming\pypoetry\auth.toml
+    [http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]
+    username = "{personal access token name}"
+    password = "{personal access token}"
+    ```
+1. Create a `.env` file in the project directory that [Docker Compose reads](https://docs.docker.com/compose/env-file/) to pass Poetry's `auth.toml` file as a [build and run time secret](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets-configuration-reference):
     ```sh
-    # bash
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME='{personal access token name}'" >> ~/.bash_profile
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD='{personal access token}'" >> ~/.bash_profile
-    
-    # fish
-    echo "set --export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME '{personal access token name}'" >> ~/.config/fish/config.fish
-    echo "set --export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD '{personal access token}'" >> ~/.config/fish/config.fish
+    # Linux
+    POETRY_AUTH_TOML_PATH=~/.config/pypoetry/auth.toml
 
-    # zsh
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME='{personal access token name}'" >> ~/.zshenv
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD='{personal access token}'" >> ~/.zshenv
+    # macOS
+    POETRY_AUTH_TOML_PATH=~/Library/Application Support/pypoetry/auth.toml
+
+    # Windows
+    POETRY_AUTH_TOML_PATH=$APPDATA/pypoetry/auth.toml
     ```
 {%- endif %}
 {%- else -%}
@@ -56,37 +62,29 @@ To add and install this package as a dependency of your project, run `poetry add
     EOF
     ```
 {%- if cookiecutter.private_package_repository_name %}
-1. [Configure Poetry's credentials for this package's private repository](https://python-poetry.org/docs/repositories/#configuring-credentials):
+1. [Add your private package repository credentials to your Poetry's `auth.toml` file](https://python-poetry.org/docs/repositories/#configuring-credentials):
+    ```toml
+    # Linux:   ~/.config/pypoetry/auth.toml
+    # macOS:   ~/Library/Application Support/pypoetry/auth.toml
+    # Windows: C:\Users\%USERNAME%\AppData\Roaming\pypoetry\auth.toml
+    [http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]
+    username = "{username}"
+    password = "{password}"
+    ```
+1. Create a `.env` file in the project directory that [Docker Compose reads](https://docs.docker.com/compose/env-file/) to pass Poetry's `auth.toml` file as a [build and run time secret](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets-configuration-reference):
     ```sh
-    # bash
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME='{username}'" >> ~/.bash_profile
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD='{password}'" >> ~/.bash_profile
-    
-    # fish
-    echo "set --export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME '{username}'" >> ~/.config/fish/config.fish
-    echo "set --export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD '{password}'" >> ~/.config/fish/config.fish
+    # Linux
+    POETRY_AUTH_TOML_PATH=~/.config/pypoetry/auth.toml
 
-    # zsh
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME='{username}'" >> ~/.zshenv
-    echo "export POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD='{password}'" >> ~/.zshenv
+    # macOS
+    POETRY_AUTH_TOML_PATH=~/Library/Application Support/pypoetry/auth.toml
+
+    # Windows
+    POETRY_AUTH_TOML_PATH=$APPDATA/pypoetry/auth.toml
     ```
 {%- endif %}
 {%- endif %}
-1. [Install Docker Desktop](https://www.docker.com/get-started).
-1. [Configure Docker and Docker Compose to use the BuildKit build system](https://pythonspeed.com/articles/docker-buildkit/):
-    ```sh
-    # bash
-    echo "export DOCKER_BUILDKIT=1" >> ~/.bash_profile
-    echo "export COMPOSE_DOCKER_CLI_BUILD=1" >> ~/.bash_profile
-
-    # fish
-    echo "set --export DOCKER_BUILDKIT 1" >> ~/.config/fish/config.fish
-    echo "set --export COMPOSE_DOCKER_CLI_BUILD 1" >> ~/.config/fish/config.fish
-    
-    # zsh
-    echo "export DOCKER_BUILDKIT=1" >> ~/.zshenv
-    echo "export COMPOSE_DOCKER_CLI_BUILD=1" >> ~/.zshenv
-    ```
+1. [Install Docker Desktop](https://www.docker.com/get-started). If you are using Linux, you must [configure Docker and Docker Compose to use the BuildKit build system](https://pythonspeed.com/articles/docker-buildkit/). On macOS and Windows, BuildKit is enabled by default in Docker Desktop.
 1. [Install VS Code](https://code.visualstudio.com/) and [VS Code's Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Alternatively, install [PyCharm](https://www.jetbrains.com/pycharm/download/).
 1. _Optional:_ [Install FiraCode Nerd Font](https://www.nerdfonts.com/font-downloads) with `brew tap homebrew/cask-fonts && brew install --cask font-fira-code-nerd-font` and [configure VS Code](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions) or [configure PyCharm](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions) to use `'FiraCode Nerd Font'`.
 

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -3,24 +3,28 @@ version: "3.9"
 services:
   dev:
     build:
-      args:
-        {%- if cookiecutter.private_package_repository_name %}
-        POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME: $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
-        POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD: $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
-        {%- else %}
-        POETRY_PYPI_TOKEN_PYPI: $POETRY_PYPI_TOKEN_PYPI
-        {%- endif %}
       context: .
       target: dev
+      {%- if cookiecutter.private_package_repository_name %}
+      secrets:
+        - poetry_auth
+      {%- endif %}
     tty: true
     entrypoint: []
     command:
       [
         "sh",
         "-c",
+        {%- if cookiecutter.private_package_repository_name %}
+        "cp --update /var/lib/poetry/poetry.lock /app/ && cp --update /var/lib/git/* /app/.git/hooks/ && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml && sleep infinity"
+        {%- else %}
         "cp --update /var/lib/poetry/poetry.lock /app/ && cp --update /var/lib/git/* /app/.git/hooks/ && sleep infinity"
+        {%- endif %}
       ]
     environment:
+      {%- if not cookiecutter.private_package_repository_name %}
+      - POETRY_PYPI_TOKEN_PYPI
+      {%- endif %}
       - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
     hostname: "{{ cookiecutter.package_name|slugify }}-dev.local"
@@ -29,26 +33,24 @@ services:
     expose:
       - "8000"
     {%- endif %}
+    {%- if cookiecutter.private_package_repository_name %}
+    secrets:
+      - poetry_auth
+    {%- endif %}
     volumes:
-      # app
       - .:/app/:cached
-      # git
       - ~/.gitconfig:/etc/gitconfig:cached
-      # ssh
       - ${SSH_AGENT_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/run/host-services/ssh-auth.sock:cached
       - ~/.ssh/known_hosts:/root/.ssh/known_hosts:cached
   {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   app:
     build:
-      args:
-        {%- if cookiecutter.private_package_repository_name %}
-        POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME: $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
-        POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD: $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
-        {%- else %}
-        POETRY_PYPI_TOKEN_PYPI: $POETRY_PYPI_TOKEN_PYPI
-        {%- endif %}
       context: .
       target: app
+      {%- if cookiecutter.private_package_repository_name %}
+      secrets:
+        - poetry_auth
+      {%- endif %}
     tty: true
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
     hostname: "{{ cookiecutter.package_name|slugify }}.local"
@@ -60,3 +62,9 @@ services:
     profiles:
       - app
   {%- endif %}
+{%- if cookiecutter.private_package_repository_name %}
+
+secrets:
+  poetry_auth:
+    file: $POETRY_AUTH_TOML_PATH
+{%- endif %}

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -16,9 +16,9 @@ services:
         "sh",
         "-c",
         {%- if cookiecutter.private_package_repository_name %}
-        "cp --update /var/lib/poetry/poetry.lock /app/ && cp --update /var/lib/git/* /app/.git/hooks/ && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml && sleep infinity"
+        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/ && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml && sleep infinity"
         {%- else %}
-        "cp --update /var/lib/poetry/poetry.lock /app/ && cp --update /var/lib/git/* /app/.git/hooks/ && sleep infinity"
+        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/ && sleep infinity"
         {%- endif %}
       ]
     environment:

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -94,7 +94,7 @@ shellcheck-py = "^0.8.0"
 
 # https://python-poetry.org/docs/repositories/#using-a-private-repository
 [[tool.poetry.source]]
-name = "{{ cookiecutter.private_package_repository_name|lower }}"
+name = "{{ cookiecutter.private_package_repository_name|slugify }}"
 url = "{{ cookiecutter.private_package_repository_url }}"
 {%- endif %}
 

--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -12,10 +12,6 @@ stages:
     DOCKER_REGISTRY: $CI_REGISTRY
     DOCKER_REGISTRY_USER: $CI_REGISTRY_USER
     DOCKER_REGISTRY_PASSWORD: $CI_REGISTRY_PASSWORD
-    {%- if cookiecutter.private_package_repository_name %}
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME: gitlab-ci-token
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD: $CI_JOB_TOKEN
-    {%- endif %}
   script:
     - DOCKER_IMAGE_SHA="${DOCKER_IMAGE_SHA:-$(sha1sum Dockerfile poetry.lock pyproject.toml | sha1sum | cut -c 1-12)}"
     - echo "CI_IMAGE_SHA=$DOCKER_IMAGE_SHA" >> .env
@@ -37,6 +33,11 @@ stages:
         done
 
         # Build the Docker image with all of the selected tags.
+        {%- if cookiecutter.private_package_repository_name %}
+        echo "[http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]" >> auth.toml
+        echo "username = \"gitlab-ci-token\"" >> auth.toml
+        echo "password = \"$CI_JOB_TOKEN\"" >> auth.toml
+        {%- endif %}
         DOCKER_BUILDKIT=1 docker build \
           {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
           --build-arg APP_BASE_IMAGE="${DOCKER_BASE_IMAGE:-ci}" \
@@ -45,8 +46,7 @@ stages:
           --build-arg SOURCE_COMMIT="$CI_COMMIT_SHA" \
           --build-arg SOURCE_TIMESTAMP="$CI_COMMIT_TIMESTAMP" \
           {%- if cookiecutter.private_package_repository_name %}
-          --secret id=poetry-http-basic-username,env=POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME \
-          --secret id=poetry-http-basic-password,env=POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD \
+          --secret id=poetry_auth,src=auth.toml \
           {%- endif %}
           --target "$DOCKER_TARGET" \
           --pull \
@@ -80,12 +80,10 @@ Test:
     paths:
       - .mypy_cache/
       - .pytest_cache/
-  {%- if cookiecutter.private_package_repository_name %}
-  variables:
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME: gitlab-ci-token
-    POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD: $CI_JOB_TOKEN
-  {%- endif %}
   script:
+    {%- if cookiecutter.private_package_repository_name %}
+    - poetry config http-basic.{{ cookiecutter.private_package_repository_name|slugify }} "gitlab-ci-token" "$CI_JOB_TOKEN"
+    {%- endif %}
     - poetry install --no-interaction  # TODO: Add `--only test` when Poetry 1.2.0 is released.
     - poe lint
     - poe test
@@ -106,11 +104,11 @@ Publish:
   image: $CI_REGISTRY_IMAGE/ci:$CI_IMAGE_SHA
   script:
     {%- if cookiecutter.private_package_repository_name %}
-    - poetry config repositories.private "{{ cookiecutter.private_package_repository_url.replace('simple', '') }}"
+    - poetry config repositories.private "{{ cookiecutter.private_package_repository_url.replace('simple/', '').replace('simple', '') }}"
     - poetry config http-basic.private "gitlab-ci-token" "$CI_JOB_TOKEN"
     - poetry publish --build --repository private
     {%- else %}
-    - poetry config http-basic.pypi "__token__" "$POETRY_PYPI_TOKEN_PYPI"
+    - poetry config pypi-token.pypi "$POETRY_PYPI_TOKEN_PYPI"
     - poetry publish --build
     {%- endif %}
   only:


### PR DESCRIPTION
- [Docker Compose v2.5.0](https://github.com/docker/compose/releases/tag/v2.5.0) (released 2022-04-29) adds support for build time secrets.
- [Docker Desktop 4.8.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-480) (released 2022-05-06) ships with Docker Compose v2.5.0.
- Before this PR, build time secrets were implemented for the Docker CLI only. For Docker Compose, build time secrets were implemented as environment variables.
- Before this PR, run time secrets were implemented as environment variables.
- After this PR, build and run time secrets are supported for both the Docker CLI as well as Docker Compose.
- This PR also simplifies the one-time setup in a few ways:
  - Poetry credentials are now managed in Poetry's `auth.toml`.
  - It is no longer needed to configure Docker & Docker Compose to use BuildKit on macOS and Windows since this it is enabled by default in Docker Desktop on those platforms.