### PR TITLE
feat: use venv to manage app dependencies

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
         ],
         "files.autoSave": "onFocusChange",
         "python.analysis.typeCheckingMode": "off",
-        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.defaultInterpreterPath": "/opt/app-env/bin/python",
         "python.formatting.provider": "black",
         "python.languageServer": "Pylance",
         "python.linting.flake8Enabled": true,

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -28,18 +28,6 @@ ENV PATH /root/.local/bin:$PATH
 RUN --mount=type=cache,target=/root/.cache/ \
     curl -sSL https://install.python-poetry.org | python - --version $POETRY_VERSION
 
-# Enable Poetry to publish to {% if cookiecutter.private_package_repository_name %}and install from a private package repository{% else %}PyPI{% endif %} [1].
-# [1] https://pythonspeed.com/articles/build-secrets-docker-compose/
-{%- if cookiecutter.private_package_repository_name %}
-ARG POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
-ENV POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
-ARG POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
-ENV POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
-{%- else %}
-ARG POETRY_PYPI_TOKEN_PYPI
-ENV POETRY_PYPI_TOKEN_PYPI $POETRY_PYPI_TOKEN_PYPI
-{%- endif %}
-
 # Create and activate a virtual environment.
 RUN python -m venv /opt/app-env
 ENV PATH=/opt/app-env/bin:$PATH

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -24,13 +24,26 @@ ENV PYTHONUNBUFFERED 1
 
 # Install Poetry.
 ENV POETRY_VERSION 1.1.13
-ENV PATH /root/.local/bin/:$PATH
+ENV PATH /root/.local/bin:$PATH
 RUN --mount=type=cache,target=/root/.cache/ \
-    curl -sSL https://install.python-poetry.org | python - --version $POETRY_VERSION && \
-    poetry config virtualenvs.create false
+    curl -sSL https://install.python-poetry.org | python - --version $POETRY_VERSION
 
-# Let Poe the Poet know it doesn't need to activate the Python environment.
-ENV POETRY_ACTIVE 1
+# Enable Poetry to publish to {% if cookiecutter.private_package_repository_name %}and install from a private package repository{% else %}PyPI{% endif %} [1].
+# [1] https://pythonspeed.com/articles/build-secrets-docker-compose/
+{%- if cookiecutter.private_package_repository_name %}
+ARG POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
+ENV POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_USERNAME
+ARG POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
+ENV POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD $POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|upper|replace("-", "_") }}_PASSWORD
+{%- else %}
+ARG POETRY_PYPI_TOKEN_PYPI
+ENV POETRY_PYPI_TOKEN_PYPI $POETRY_PYPI_TOKEN_PYPI
+{%- endif %}
+
+# Create and activate a virtual environment.
+RUN python -m venv /opt/app-env
+ENV PATH=/opt/app-env/bin:$PATH
+ENV VIRTUAL_ENV=/opt/app-env
 
 # Set the working directory.
 WORKDIR /app/
@@ -69,10 +82,10 @@ COPY . .
 
 # Expose the application.
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-ENTRYPOINT ["/usr/local/bin/poe"]
+ENTRYPOINT ["/opt/app-env/bin/poe"]
 CMD [{% if cookiecutter.with_fastapi_api|int %}"serve"{% else %}"streamlit"{% endif %}]
 {%- else %}
-ENTRYPOINT ["/usr/local/bin/{{ cookiecutter.package_name|slugify }}"]
+ENTRYPOINT ["/opt/app-env/bin/{{ cookiecutter.package_name|slugify }}"]
 CMD []
 {%- endif %}
 


### PR DESCRIPTION
- [Use an explicit virtual environment to install all Poetry-managed dev and run time dependencies in](https://github.com/python-poetry/poetry/issues/1579#issuecomment-863737675)
- [Automatically activate the virtual environment](https://pythonspeed.com/articles/activate-virtualenv-dockerfile/) in the Docker image
- Removes messages from Poetry or Poe about not activating a virtual environment
- There are now three environments in the image:
  - The system environment
  - Poetry's virtual environment
  - The application's virtual environment