### PR TITLE
fix: minimize devcontainer settings

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
@@ -33,7 +33,6 @@
         "python.terminal.activateEnvironment": false,
         "python.testing.pytestEnabled": true,
         "terminal.integrated.defaultProfile.linux": "zsh",
-        "terminal.integrated.inheritEnv": false,
         "terminal.integrated.profiles.linux": {
             "zsh": {
                 "path": "/usr/bin/zsh"

--- a/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
@@ -19,25 +19,19 @@
         "editor.codeActionsOnSave": {
             "source.organizeImports": true
         },
-        "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.rulers": [
             100
         ],
         "files.autoSave": "onFocusChange",
-        "python.analysis.typeCheckingMode": "off",
         "python.defaultInterpreterPath": "/opt/app-env/bin/python",
         "python.formatting.provider": "black",
-        "python.languageServer": "Pylance",
         "python.linting.flake8Enabled": true,
         "python.linting.mypyEnabled": true,
         "python.linting.pydocstyleEnabled": true,
         "python.linting.pylintEnabled": false,
         "python.terminal.activateEnvironment": false,
-        "python.terminal.activateEnvInCurrentTerminal": false,
-        "python.testing.nosetestsEnabled": false,
         "python.testing.pytestEnabled": true,
-        "python.testing.unittestEnabled": false,
         "terminal.integrated.defaultProfile.linux": "zsh",
         "terminal.integrated.inheritEnv": false,
         "terminal.integrated.profiles.linux": {


### PR DESCRIPTION
This PR minimises the `devcontainer.json` and by doing so also fixes the startup warning (specifically, by not explicitly setting the language server to `Pylance` – which is the default anyway):
> The Pylance extension is not installed but the python.languageServer value is set to "Pylance". Would you like to install the Pylance extension to use Pylance, or revert back to Jedi? 