### PR TITLE
feat: improve docker compose networking

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/README.md
+++ b/{{ cookiecutter.package_name|slugify }}/README.md
@@ -5,7 +5,11 @@
 {% if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int -%}
 ## Using
 
-To serve this package, run `docker-compose up app`.
+To serve this app, run `docker compose up app` and open [localhost:8000](http://localhost:8000) in your browser.
+{% elif cookiecutter.with_typer_cli|int -%}
+## Using
+
+To use this app, run `docker compose run --rm app {commmand}`.
 {%- else -%}
 ## Installing
 

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -27,10 +27,7 @@ services:
       {%- endif %}
       - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-    hostname: "{{ cookiecutter.package_name|slugify }}-dev.local"
     ports:
-      - "8000"
-    expose:
       - "8000"
     {%- endif %}
     {%- if cookiecutter.private_package_repository_name %}
@@ -54,11 +51,8 @@ services:
       {%- endif %}
     tty: true
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-    hostname: "{{ cookiecutter.package_name|slugify }}.local"
     ports:
-      - "8000"
-    expose:
-      - "8000"
+      - "8000:8000"
     {%- endif %}
     profiles:
       - app


### PR DESCRIPTION
- [x] Remove unused `expose` and `hostname` keys in `docker-compose.yml`.
- [x] Explicitly set the host port to 8000 when explicitly serving the app to make it easier to access at [localhost:8000](http://localhost:8000). Note: the host port is still randomly chosen when running a dev container so that you can run multiple dev containers side by side without the ports clashing.
- [x] Improve the README by explaining how to use the app or package, depending on whether it is servable, a CLI, or a Python package.