### PR TITLE
fix: add build-essentials to devcontainer

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -1,7 +1,4 @@
 # syntax=docker/dockerfile:experimental
-{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
-ARG APP_BASE_IMAGE=ci
-{%- endif %}
 
 FROM python:{{ cookiecutter.python_version }}-slim AS base
 
@@ -25,12 +22,12 @@ WORKDIR /app/
 
 FROM base as dev
 
-# Install development tools: curl, git, gpg, ssh, starship, vim, and zsh.
+# Install development tools: compilers, curl, git, gpg, ssh, starship, vim, and zsh.
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     --mount=type=cache,id=apt-lib,target=/var/lib/apt/ \
     apt-get update && \
-    apt-get install --no-install-recommends --yes curl git gnupg ssh vim zsh zsh-antigen && \
+    apt-get install --no-install-recommends --yes build-essential curl git gnupg ssh vim zsh zsh-antigen && \
     chsh --shell /usr/bin/zsh && \
     sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- "--yes" && \
     echo 'source /usr/share/zsh-antigen/antigen.zsh' >> ~/.zshrc && \
@@ -63,7 +60,7 @@ RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
     poetry install --no-dev --no-interaction
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
 
-FROM $APP_BASE_IMAGE AS app
+FROM ci AS app
 
 # Copy the package source code to the working directory.
 COPY src/ *.py /app/

--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -39,9 +39,6 @@ stages:
         echo "password = \"$CI_JOB_TOKEN\"" >> auth.toml
         {%- endif %}
         DOCKER_BUILDKIT=1 docker build \
-          {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-          --build-arg APP_BASE_IMAGE="${DOCKER_BASE_IMAGE:-ci}" \
-          {%- endif %}
           --build-arg SOURCE_BRANCH="$CI_COMMIT_REF_NAME" \
           --build-arg SOURCE_COMMIT="$CI_COMMIT_SHA" \
           --build-arg SOURCE_TIMESTAMP="$CI_COMMIT_TIMESTAMP" \
@@ -122,7 +119,6 @@ Publish:
     - .docker
   stage: deploy
   variables:
-    DOCKER_BASE_IMAGE: $CI_REGISTRY_IMAGE/ci:$CI_IMAGE_SHA
     DOCKER_IMAGE: $CI_REGISTRY_IMAGE
     DOCKER_IMAGE_SHA: ${CI_COMMIT_TAG:-$CI_COMMIT_SHORT_SHA}
     DOCKER_PUSH: 1


### PR DESCRIPTION
Build-essential is still needed on Apple silicon for certain (transitive) dependencies such as ruamel.yaml.