### PR TITLE
feat: improve SSH key loading

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
     "dockerComposeFile": "../docker-compose.yml",
     "service": "dev",
     "workspaceFolder": "/app/",
+    "initializeCommand": "ssh-add --apple-load-keychain || true",
     "extensions": [
         "bungcip.better-toml",
         "eamodio.gitlens",

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -21,11 +21,10 @@ services:
         "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/ && sleep infinity"
         {%- endif %}
       ]
+    {%- if not cookiecutter.private_package_repository_name %}
     environment:
-      {%- if not cookiecutter.private_package_repository_name %}
       - POETRY_PYPI_TOKEN_PYPI
-      {%- endif %}
-      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+    {%- endif %}
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
     ports:
       - "8000"
@@ -37,7 +36,6 @@ services:
     volumes:
       - .:/app/:cached
       - ~/.gitconfig:/etc/gitconfig:cached
-      - ${SSH_AGENT_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/run/host-services/ssh-auth.sock:cached
       - ~/.ssh/known_hosts:/root/.ssh/known_hosts:cached
       - app-env:/opt/app-env/
   {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}


### PR DESCRIPTION
Problem: SSH keys are no longer automatically loaded when needed with the workaround proposed in https://github.com/microsoft/vscode-remote-release/issues/4024.

Solution:
- Linux and Windows users will have to make sure to [load their SSH keys on the host as the Remote Containers documentation recommends](https://code.visualstudio.com/docs/remote/containers#_using-ssh-keys).
- SSH keys are automatically loaded on macOS by adding `ssh-add --apple-load-keychain` to the `devcontainer.json`'s `initializeCommand`.