### PR TITLE
feat: minimize Docker volumes

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -35,8 +35,6 @@ services:
     {%- endif %}
     volumes:
       - .:/app/:cached
-      - ~/.gitconfig:/etc/gitconfig:cached
-      - ~/.ssh/known_hosts:/root/.ssh/known_hosts:cached
       - app-env:/opt/app-env/
   {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   app:

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - poetry_auth
     {%- endif %}
     volumes:
-      - .:/app/:cached
+      - .:/app/
       - app-env:/opt/app-env/
   {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   app:


### PR DESCRIPTION
[From VS Code's Remote Containers extension documentation](https://code.visualstudio.com/docs/remote/containers#_sharing-git-credentials-with-your-container):
> The extension will automatically copy your local `.gitconfig` file into the container on startup so you should not need to do this in the container itself.

This PR removes unnecessary Docker volume mounts as VS Code will automatically copy these into the container:
- `~/.gitconfig`
- `~/.ssh/known_hosts`

For PyCharm, the Dev Container is used as an execution environment and not as a development environment, so I believe these mounts are also not necessary there either (but correct me if I'm wrong!).

Another improvement in this PR is that it removes [the now deprecated `:cached` flag](https://github.com/microsoft/vscode-remote-release/issues/6124).