### PR TITLE
feat: better dev containers

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
@@ -4,6 +4,8 @@
     "service": "dev",
     "workspaceFolder": "/app/",
     "initializeCommand": "ssh-add --apple-load-keychain || true",
+    "overrideCommand": true,
+    "postStartCommand": "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/{% if cookiecutter.private_package_repository_name %} && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml{% endif %}",
     "extensions": [
         "bungcip.better-toml",
         "eamodio.gitlens",

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:experimental
-
 FROM python:{{ cookiecutter.python_version }}-slim AS base
 
 # Configure Python to print tracebacks on crash [1], and to not buffer stdout and stderr [2].
@@ -33,7 +32,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     echo 'source /usr/share/zsh-antigen/antigen.zsh' >> ~/.zshrc && \
     echo 'antigen bundle zsh-users/zsh-autosuggestions' >> ~/.zshrc && \
     echo 'antigen apply' >> ~/.zshrc && \
-    echo 'eval "$(starship init zsh)"' >> ~/.zshrc
+    echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
+    zsh -c 'source ~/.zshrc'
 
 # Install the development Python environment.
 COPY .pre-commit-config.yaml poetry.lock* pyproject.toml /app/

--- a/{{ cookiecutter.package_name|slugify }}/README.md
+++ b/{{ cookiecutter.package_name|slugify }}/README.md
@@ -89,7 +89,10 @@ To serve this app, run `docker compose up app` and open [localhost:8000](http://
     POETRY_AUTH_TOML_PATH="$APPDATA/pypoetry/auth.toml"
     ```
 {%- endif %}
-1. Open the cloned repository in VS Code and run <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd> → _Remote-Containers: Reopen in Container_ to start a [Dev Container](https://code.visualstudio.com/docs/remote/containers). Alternatively, open the cloned repository in PyCharm and [configure Docker Compose as a remote interpreter](https://www.jetbrains.com/help/pycharm/using-docker-compose-as-a-remote-interpreter.html#docker-compose-remote).
+1. Start a [Dev Container](https://code.visualstudio.com/docs/remote/containers) in your preferred development environment:
+    - _VS Code_: open the cloned repository and run <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd> → _Remote-Containers: Reopen in Container_.
+    - _PyCharm_: open the cloned repository and [configure Docker Compose as a remote interpreter](https://www.jetbrains.com/help/pycharm/using-docker-compose-as-a-remote-interpreter.html#docker-compose-remote).
+    - _Terminal_: open the cloned repository and run `docker compose run --rm dev` to start an interactive Dev Container.
 
 </details>
 

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -9,22 +9,20 @@ services:
       secrets:
         - poetry_auth
       {%- endif %}
+    stdin_open: true
     tty: true
     entrypoint: []
     command:
       [
         "sh",
         "-c",
-        {%- if cookiecutter.private_package_repository_name %}
-        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/ && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml && sleep infinity"
-        {%- else %}
-        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/ && sleep infinity"
-        {%- endif %}
+        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/{% if cookiecutter.private_package_repository_name %} && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml{% endif %} && zsh"
       ]
-    {%- if not cookiecutter.private_package_repository_name %}
     environment:
+      {%- if not cookiecutter.private_package_repository_name %}
       - POETRY_PYPI_TOKEN_PYPI
-    {%- endif %}
+      {%- endif %}
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
     ports:
       - "8000"
@@ -34,10 +32,13 @@ services:
       - poetry_auth
     {%- endif %}
     volumes:
-      - .:/app/:cached
-      - ~/.gitconfig:/etc/gitconfig:cached
-      - ~/.ssh/known_hosts:/root/.ssh/known_hosts:cached
+      - .:/app/
       - app-env:/opt/app-env/
+      - ~/.gitconfig:/etc/gitconfig
+      - ~/.ssh/known_hosts:/root/.ssh/known_hosts
+      - ${SSH_AGENT_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/run/host-services/ssh-auth.sock
+    profiles:
+      - dev
   {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   app:
     build:
@@ -52,8 +53,6 @@ services:
     ports:
       - "8000:8000"
     {%- endif %}
-    profiles:
-      - app
   {%- endif %}
 {%- if cookiecutter.private_package_repository_name %}
 


### PR DESCRIPTION
Improvements:
1. [x] You can now run `docker compose run --rm dev` to start a Dev Container from the terminal. This is useful if you want to work from within the Dev Container without using VS Code or PyCharm. Also, if you use PyCharm, you will probably need to run the Dev Container alongside it like this to actually run commands like `poetry add` or `git commit` from within the environment.
    - `stdin_open: true` is added to the `dev` service to enable (1) to drop you into stdin (equivalent to `docker run -i`).
    - `zsh` is now the default command in `docker-compose.yml` so that you drop into `zsh` with `docker compose run`.
2. [x] The host's SSH agent is mounted again, otherwise a Terminal-based Dev Container (1) would not be very useful.
3. [x] Because (1) interferes with VS Code's Dev Containers, we now add `"overrideCommand": true` to `devcontainer.json`. This has the effect of starting the container with `sleep infinity` so that it doesn't quit. Because this replaces the startup command, we also need a `postStartCommand` to copy the files we need into the mounted volume as we do in the `docker-compose.yml`.
4. [x] `zsh -c 'source ~/.zshrc'` is added to the `Dockerfile` to speed up starting the Dev Container, since all zsh plugins will have been installed at build time.
5. [x] The `README.md` has been improved with 3 options to run your Dev Container: VS Code, PyCharm, and Terminal.
6. [x] The `dev` service now has a `dev` profile, and the `app` service no longer has any profile. This allows you to run `docker compose up` without any arguments and it will start the `app` service only (because it will not start any services with other profiles unless you ask it to).

Replaces #56.