### PR TITLE
feat: improved dependabot updates

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.github/dependabot.yml
+++ b/{{ cookiecutter.package_name|slugify }}/.github/dependabot.yml
@@ -5,7 +5,18 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "ci(deps)"
+      prefix-development: "ci(deps)"
+      include: "scope"
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps)"
+      include: "scope"
+    versioning-strategy: lockfile-only
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
- [x] Dependabot now creates Conventional Commits, so its PRs can be merged without edits.
- [x] Dependencies are now only updated in the `poetry.lock` file instead of in `pyproject.toml`. The benefit of this is that `pyproject.toml` is a specification, and the actually installed dependencies are updated within the constraints of that specification. There is a benefit to updating the specification itself, but right now that creates many merge conflicts [1].
- [x] Transitive dependencies are also updated automatically.

[1] https://github.com/dependabot/dependabot-core/issues/4435