### PR TITLE
feat: Improve Docker caching on GitLab CI

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -23,7 +23,7 @@ FROM base as deps
 
 # Install the run time Python environment.
 # TODO: Replace `--no-dev` with `--without test` when Poetry 1.2.0 is released.
-COPY poetry.lock pyproject.toml /app/
+COPY poetry.lock* pyproject.toml /app/
 RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
     --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -59,6 +59,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
     zsh -c 'source ~/.zshrc'
 
+# Persist output generated during docker build so that we can restore it in the dev container.
 RUN mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
     git init && pre-commit install --install-hooks && \
     mkdir -p /var/lib/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /var/lib/git/

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -38,7 +38,6 @@ RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
 FROM deps as ci
 
 # Install the development Python environment.
-COPY .pre-commit-config.yaml /app/
 RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
     --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
@@ -60,6 +59,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     echo 'antigen apply' >> ~/.zshrc && \
     echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
     zsh -c 'source ~/.zshrc'
+
+COPY .pre-commit-config.yaml /app/
 
 # Persist output generated during docker build so that we can restore it in the dev container.
 RUN mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -29,7 +29,6 @@ RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
     {%- endif %}
     mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
     poetry install --no-dev --no-interaction
-{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
 
 FROM deps as ci
 
@@ -63,6 +62,7 @@ RUN mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
     git init && pre-commit install --install-hooks && \
     mkdir -p /var/lib/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /var/lib/git/
 
+{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
 FROM deps AS app
 
 # Copy the package source code to the working directory.

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -38,7 +38,6 @@ RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
     --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
     {%- endif %}
-    mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
     poetry install --no-interaction
 
 FROM ci as dev

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -66,8 +66,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
 RUN mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
     git init && pre-commit install --install-hooks && \
     mkdir -p /var/lib/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /var/lib/git/
-
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
+
 FROM deps AS app
 
 # Copy the package source code to the working directory.

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -19,7 +19,31 @@ ENV VIRTUAL_ENV /opt/app-env
 # Set the working directory.
 WORKDIR /app/
 
-FROM base as dev
+FROM base as deps
+
+# Install the run time Python environment.
+# TODO: Replace `--no-dev` with `--without test` when Poetry 1.2.0 is released.
+COPY poetry.lock pyproject.toml /app/
+RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
+    {%- if cookiecutter.private_package_repository_name %}
+    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
+    {%- endif %}
+    mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
+    poetry install --no-dev --no-interaction
+{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
+
+FROM deps as ci
+
+# Install the development Python environment.
+COPY .pre-commit-config.yaml poetry.lock* pyproject.toml /app/
+RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
+    {%- if cookiecutter.private_package_repository_name %}
+    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
+    {%- endif %}
+    mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
+    poetry install --no-interaction
+
+FROM ci as dev
 
 # Install development tools: compilers, curl, git, gpg, ssh, starship, vim, and zsh.
 RUN rm /etc/apt/apt.conf.d/docker-clean
@@ -35,32 +59,11 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
     zsh -c 'source ~/.zshrc'
 
-# Install the development Python environment.
-COPY .pre-commit-config.yaml poetry.lock* pyproject.toml /app/
-RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
-    {%- if cookiecutter.private_package_repository_name %}
-    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
-    {%- endif %}
-    mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
-    poetry install --no-interaction && \
-    mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
+RUN mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
     git init && pre-commit install --install-hooks && \
     mkdir -p /var/lib/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /var/lib/git/
 
-FROM base as ci
-
-# Install the run time Python environment.
-# TODO: Replace `--no-dev` with `--without test` when Poetry 1.2.0 is released.
-COPY poetry.lock pyproject.toml /app/
-RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
-    {%- if cookiecutter.private_package_repository_name %}
-    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
-    {%- endif %}
-    mkdir -p src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/ && touch src/{{ cookiecutter.package_name|slugify|replace("-", "_") }}/__init__.py && touch README.md && \
-    poetry install --no-dev --no-interaction
-{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
-
-FROM ci AS app
+FROM deps AS app
 
 # Copy the package source code to the working directory.
 COPY src/ *.py /app/

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -22,7 +22,6 @@ WORKDIR /app/
 FROM base as deps
 
 # Install the run time Python environment.
-# TODO: Replace `--no-dev` with `--without test` when Poetry 1.2.0 is released.
 COPY poetry.lock* pyproject.toml /app/
 RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app/
 
 FROM base as deps
 
+# Install compilers that may be required for certain packages or platforms.
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     --mount=type=cache,id=apt-lib,target=/var/lib/apt/ \
     apt-get update && \

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -21,7 +21,6 @@ WORKDIR /app/
 
 FROM base as deps
 
-RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     --mount=type=cache,id=apt-lib,target=/var/lib/apt/ \
     apt-get update && \

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -61,9 +61,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
     zsh -c 'source ~/.zshrc'
 
-COPY .pre-commit-config.yaml /app/
-
 # Persist output generated during docker build so that we can restore it in the dev container.
+COPY .pre-commit-config.yaml /app/
 RUN mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
     git init && pre-commit install --install-hooks && \
     mkdir -p /var/lib/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /var/lib/git/

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -21,6 +21,12 @@ WORKDIR /app/
 
 FROM base as deps
 
+RUN rm /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
+    --mount=type=cache,id=apt-lib,target=/var/lib/apt/ \
+    apt-get update && \
+    apt-get install --no-install-recommends --yes build-essential
+
 # Install the run time Python environment.
 COPY poetry.lock* pyproject.toml /app/
 RUN --mount=type=cache,id=poetry,target=/root/.cache/ \

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
 FROM deps as ci
 
 # Install the development Python environment.
-COPY .pre-commit-config.yaml poetry.lock* pyproject.toml /app/
+COPY .pre-commit-config.yaml /app/
 RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
     --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \

--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -66,8 +66,8 @@ Compute Image Hash:
   rules:
     - changes:
         - Dockerfile
-        - pyproject.toml
         - poetry.lock
+        - pyproject.toml
 
 # Build CI Docker image.
 Build CI:

--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -25,7 +25,6 @@ Compute Image Hash:
     - |
       echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin "$DOCKER_REGISTRY"
       DOCKER_PUSH=${DOCKER_PUSH:-$(timeout 2s docker pull "$DOCKER_IMAGE":"$DOCKER_IMAGE_SHA" >/dev/null 2>&1 && echo $? || echo $?)}
-
       if [ "$DOCKER_PUSH" -ne 1 ]; then
         echo "$DOCKER_IMAGE:$DOCKER_IMAGE_SHA exists, skipping this job..."
       else

--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -3,6 +3,15 @@ stages:
   - test
   - {% if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}deploy{% else %}publish{% endif %}
 
+Compute Image Hash:
+  stage: build
+  script:
+    - export DOCKER_IMAGE_SHA="$(sha1sum Dockerfile poetry.lock pyproject.toml | sha1sum | cut -c 1-12)"
+    - echo "CI_IMAGE_SHA=$DOCKER_IMAGE_SHA" >> .env
+  artifacts:
+    reports:
+      dotenv: .env
+
 # Base Docker build script.
 .docker:
   image: docker:stable
@@ -13,48 +22,49 @@ stages:
     DOCKER_REGISTRY_USER: $CI_REGISTRY_USER
     DOCKER_REGISTRY_PASSWORD: $CI_REGISTRY_PASSWORD
   script:
-    - DOCKER_IMAGE_SHA="${DOCKER_IMAGE_SHA:-$(sha1sum Dockerfile poetry.lock pyproject.toml | sha1sum | cut -c 1-12)}"
-    - echo "CI_IMAGE_SHA=$DOCKER_IMAGE_SHA" >> .env
     - |
       echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin "$DOCKER_REGISTRY"
       DOCKER_PUSH=${DOCKER_PUSH:-$(timeout 2s docker pull "$DOCKER_IMAGE":"$DOCKER_IMAGE_SHA" >/dev/null 2>&1 && echo $? || echo $?)}
-      if [ "$DOCKER_PUSH" -ne 1 ]; then
-        echo "$DOCKER_IMAGE:$DOCKER_IMAGE_SHA exists, skipping this job..."
-      else
-        # Compile a list of image tags consisting of a hash of its contents, the latest tag if this
-        # pipeline is running for the default branch, and the Git tag if this commit is tagged.
-        DOCKER_TAGS="$DOCKER_IMAGE_SHA"
-        if [ "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH" ]; then DOCKER_TAGS="$DOCKER_TAGS latest"; fi
-        if [ -n "$CI_COMMIT_TAG" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_COMMIT_TAG"; fi
-        if [ -n "$CI_ENVIRONMENT_NAME" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_ENVIRONMENT_NAME"; fi
-        DOCKER_TAGS_JOINED=""
-        for DOCKER_TAG in $DOCKER_TAGS; do
-          DOCKER_TAGS_JOINED="$DOCKER_TAGS_JOINED --tag $DOCKER_IMAGE:$DOCKER_TAG"
-        done
 
-        # Build the Docker image with all of the selected tags.
+      # Compile a list of image tags consisting of a hash of its contents, the latest tag if this
+      # pipeline is running for the default branch, and the Git tag if this commit is tagged.
+      DOCKER_TAGS="$DOCKER_IMAGE_SHA"
+      if [ "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH" ]; then DOCKER_TAGS="$DOCKER_TAGS latest"; fi
+      if [ -n "$CI_COMMIT_TAG" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_COMMIT_TAG"; fi
+      if [ -n "$CI_ENVIRONMENT_NAME" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_ENVIRONMENT_NAME"; fi
+      DOCKER_TAGS_JOINED=""
+      for DOCKER_TAG in $DOCKER_TAGS; do
+        DOCKER_TAGS_JOINED="$DOCKER_TAGS_JOINED --tag $DOCKER_IMAGE:$DOCKER_TAG"
+      done
+
+      # Build the Docker image with all of the selected tags.
+      {%- if cookiecutter.private_package_repository_name %}
+      echo "[http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]" >> auth.toml
+      echo "username = \"gitlab-ci-token\"" >> auth.toml
+      echo "password = \"$CI_JOB_TOKEN\"" >> auth.toml
+      {%- endif %}
+      DOCKER_BUILDKIT=1 docker build \
+        --cache-from "${DOCKER_BASE_IMAGE:-ci}" \
+        --build-arg SOURCE_BRANCH="$CI_COMMIT_REF_NAME" \
+        --build-arg SOURCE_COMMIT="$CI_COMMIT_SHA" \
+        --build-arg SOURCE_TIMESTAMP="$CI_COMMIT_TIMESTAMP" \
         {%- if cookiecutter.private_package_repository_name %}
-        echo "[http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]" >> auth.toml
-        echo "username = \"gitlab-ci-token\"" >> auth.toml
-        echo "password = \"$CI_JOB_TOKEN\"" >> auth.toml
+        --secret id=poetry_auth,src=auth.toml \
         {%- endif %}
-        DOCKER_BUILDKIT=1 docker build \
-          --build-arg SOURCE_BRANCH="$CI_COMMIT_REF_NAME" \
-          --build-arg SOURCE_COMMIT="$CI_COMMIT_SHA" \
-          --build-arg SOURCE_TIMESTAMP="$CI_COMMIT_TIMESTAMP" \
-          {%- if cookiecutter.private_package_repository_name %}
-          --secret id=poetry_auth,src=auth.toml \
-          {%- endif %}
-          --target "$DOCKER_TARGET" \
-          --pull \
-          $DOCKER_TAGS_JOINED \
-          .
+        --target "$DOCKER_TARGET" \
+        --pull \
+        $DOCKER_TAGS_JOINED \
+        .
 
-        # Push all the tagged images.
-        for DOCKER_TAG in $DOCKER_TAGS; do
-          docker push "$DOCKER_IMAGE:$DOCKER_TAG"
-        done
-      fi
+      # Push all the tagged images.
+      for DOCKER_TAG in $DOCKER_TAGS; do
+        docker push "$DOCKER_IMAGE:$DOCKER_TAG"
+      done
+  rules:
+    - changes:
+        - Dockerfile
+        - pyproject.toml
+        - poetry.lock
 
 # Build CI Docker image.
 Build CI:

--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -26,40 +26,44 @@ Compute Image Hash:
       echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin "$DOCKER_REGISTRY"
       DOCKER_PUSH=${DOCKER_PUSH:-$(timeout 2s docker pull "$DOCKER_IMAGE":"$DOCKER_IMAGE_SHA" >/dev/null 2>&1 && echo $? || echo $?)}
 
-      # Compile a list of image tags consisting of a hash of its contents, the latest tag if this
-      # pipeline is running for the default branch, and the Git tag if this commit is tagged.
-      DOCKER_TAGS="$DOCKER_IMAGE_SHA"
-      if [ "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH" ]; then DOCKER_TAGS="$DOCKER_TAGS latest"; fi
-      if [ -n "$CI_COMMIT_TAG" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_COMMIT_TAG"; fi
-      if [ -n "$CI_ENVIRONMENT_NAME" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_ENVIRONMENT_NAME"; fi
-      DOCKER_TAGS_JOINED=""
-      for DOCKER_TAG in $DOCKER_TAGS; do
-        DOCKER_TAGS_JOINED="$DOCKER_TAGS_JOINED --tag $DOCKER_IMAGE:$DOCKER_TAG"
-      done
+      if [ "$DOCKER_PUSH" -ne 1 ]; then
+        echo "$DOCKER_IMAGE:$DOCKER_IMAGE_SHA exists, skipping this job..."
+      else
+        # Compile a list of image tags consisting of a hash of its contents, the latest tag if this
+        # pipeline is running for the default branch, and the Git tag if this commit is tagged.
+        DOCKER_TAGS="$DOCKER_IMAGE_SHA"
+        if [ "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH" ]; then DOCKER_TAGS="$DOCKER_TAGS latest"; fi
+        if [ -n "$CI_COMMIT_TAG" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_COMMIT_TAG"; fi
+        if [ -n "$CI_ENVIRONMENT_NAME" ]; then DOCKER_TAGS="$DOCKER_TAGS $CI_ENVIRONMENT_NAME"; fi
+        DOCKER_TAGS_JOINED=""
+        for DOCKER_TAG in $DOCKER_TAGS; do
+          DOCKER_TAGS_JOINED="$DOCKER_TAGS_JOINED --tag $DOCKER_IMAGE:$DOCKER_TAG"
+        done
 
-      # Build the Docker image with all of the selected tags.
-      {%- if cookiecutter.private_package_repository_name %}
-      echo "[http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]" >> auth.toml
-      echo "username = \"gitlab-ci-token\"" >> auth.toml
-      echo "password = \"$CI_JOB_TOKEN\"" >> auth.toml
-      {%- endif %}
-      DOCKER_BUILDKIT=1 docker build \
-        --cache-from "${DOCKER_BASE_IMAGE:-ci}" \
-        --build-arg SOURCE_BRANCH="$CI_COMMIT_REF_NAME" \
-        --build-arg SOURCE_COMMIT="$CI_COMMIT_SHA" \
-        --build-arg SOURCE_TIMESTAMP="$CI_COMMIT_TIMESTAMP" \
+        # Build the Docker image with all of the selected tags.
         {%- if cookiecutter.private_package_repository_name %}
-        --secret id=poetry_auth,src=auth.toml \
+        echo "[http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]" >> auth.toml
+        echo "username = \"gitlab-ci-token\"" >> auth.toml
+        echo "password = \"$CI_JOB_TOKEN\"" >> auth.toml
         {%- endif %}
-        --target "$DOCKER_TARGET" \
-        --pull \
-        $DOCKER_TAGS_JOINED \
-        .
+        DOCKER_BUILDKIT=1 docker build \
+          --cache-from "${DOCKER_BASE_IMAGE:-ci}" \
+          --build-arg SOURCE_BRANCH="$CI_COMMIT_REF_NAME" \
+          --build-arg SOURCE_COMMIT="$CI_COMMIT_SHA" \
+          --build-arg SOURCE_TIMESTAMP="$CI_COMMIT_TIMESTAMP" \
+          {%- if cookiecutter.private_package_repository_name %}
+          --secret id=poetry_auth,src=auth.toml \
+          {%- endif %}
+          --target "$DOCKER_TARGET" \
+          --pull \
+          $DOCKER_TAGS_JOINED \
+          .
 
-      # Push all the tagged images.
-      for DOCKER_TAG in $DOCKER_TAGS; do
-        docker push "$DOCKER_IMAGE:$DOCKER_TAG"
-      done
+        # Push all the tagged images.
+        for DOCKER_TAG in $DOCKER_TAGS; do
+          docker push "$DOCKER_IMAGE:$DOCKER_TAG"
+        done
+      fi
   rules:
     - changes:
         - Dockerfile

--- a/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/{% if cookiecutter.continuous_integration == "GitLab" %}.gitlab-ci.yml{% endif %}
@@ -47,7 +47,7 @@ Compute Image Hash:
         echo "password = \"$CI_JOB_TOKEN\"" >> auth.toml
         {%- endif %}
         DOCKER_BUILDKIT=1 docker build \
-          --cache-from "${DOCKER_BASE_IMAGE:-ci}" \
+          --cache-from "$CI_REGISTRY_IMAGE/ci:$CI_IMAGE_SHA" \
           --build-arg SOURCE_BRANCH="$CI_COMMIT_REF_NAME" \
           --build-arg SOURCE_COMMIT="$CI_COMMIT_SHA" \
           --build-arg SOURCE_TIMESTAMP="$CI_COMMIT_TIMESTAMP" \


### PR DESCRIPTION
- Introduce a `deps` stage: contains Poetry dependencies
- Change the `ci` stage to also include dev dependencies (later only test dependencies)
- Completely skip the build stage if no changes have been made to Docker or Poetry files using `rules:changes`
- Use `--cache-from` + CI image SHA to speed up the `test` and `app` Docker build (`test` gets much faster because we use a cached version of the `dev` stage)

This approach has given me some really nice speedup on GitLab CI:

- We don't even start the build stage if the relevant files haven't changed, and therefore there's no need to spin up `docker-in-docker`, which saves time. This did require moving the hash computation out into a separate stage.
- The `ci` stage contains dev dependencies as well, so `poetry install` in the `test` stage is instant.
- The `app` stage is not based on the matching `ci:<SHA1 hash>` image, but is rebuilt using the `--cache-from`; by doing this we still get a build speedup as the stages up to `deps` are shared with the `ci` image and we can use its corresponding cached layers.

I've tested it on GitLab CI manually and it looks good, but an automated check might be better - not sure how we would implement that in an elegant way.