### PR TITLE
feat: persist zsh command history

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -62,9 +62,11 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     chsh --shell /usr/bin/zsh && \
     sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- "--yes" && \
     echo 'source /usr/share/zsh-antigen/antigen.zsh' >> ~/.zshrc && \
+    echo 'antigen bundle zsh-users/zsh-syntax-highlighting' >> ~/.zshrc && \
     echo 'antigen bundle zsh-users/zsh-autosuggestions' >> ~/.zshrc && \
     echo 'antigen apply' >> ~/.zshrc && \
     echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
+    echo 'HISTFILE=/opt/app-env/.zsh_history' >> ~/.zshrc && \
     zsh -c 'source ~/.zshrc'
 
 # Persist output generated during docker build so that we can restore it in the dev container.


### PR DESCRIPTION
- [x] Persists zsh command history across (rebuilt) Dev Containers (but not across different projects), which improves the usefulness of the [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) plugin. This happens by setting the `HISTFILE` environment variable. If that variable isn't set (which is the default), zsh will only story its command history in memory.
- [x] Adds syntax highlighting of zsh commands with [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting).