### PR TITLE
ci: test with devcontainer CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,71 +7,62 @@ on:
   pull_request:
 
 jobs:
-
   test:
-
     runs-on: ubuntu-latest
 
     strategy:
-
-      matrix:
-        python-version: ["3.8"]
       fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.10"]
+
+    name: Python ${{ matrix.python-version }}
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Cruft and Poetry
-        run: pip install --no-input cruft poetry
-
-      - name: Scaffold package
+      - name: Scaffold Python package
         run: |
+          pip install --no-input cruft
           cruft create --no-input --extra-context '{"package_name": "My Package", "python_version": "${{ matrix.python-version }}", "with_fastapi_api": "1", "with_typer_cli": "1"}' .
 
-      - name: Cache Python environment
-        uses: actions/cache@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
-          path: my-package/.venv/
-          key: venv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('my-package/pyproject.toml') }}
+          node-version: 16
 
-      - name: Install Python environment
+      - name: Install @devcontainers/cli
+        run: npm install --location=global @devcontainers/cli
+
+      - name: Start Dev Container
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
+          git config --global init.defaultBranch main
           git init
           git add .
-          poetry config virtualenvs.in-project true
-          poetry install --no-interaction
-          poetry run pre-commit install
+          devcontainer up --workspace-folder .
         working-directory: ./my-package/
 
       - name: Lint package
-        run: poetry run poe lint
-        working-directory: ./my-package/
+        run: devcontainer exec --workspace-folder my-package poe lint
 
       - name: Test package
-        run: poetry run poe test
-        working-directory: ./my-package/
-
-      - name: Build dev Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: ./my-package/
-          target: dev
+        run: devcontainer exec --workspace-folder my-package poe test
 
       - name: Build ci Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./my-package/
           target: ci
 
       - name: Build app Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             SOURCE_BRANCH=${{ env.GITHUB_REF }}

--- a/{{ cookiecutter.package_name|slugify }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.package_name|slugify }}/.github/workflows/test.yml
@@ -8,49 +8,33 @@ on:
   pull_request:
 
 jobs:
-
   test:
-
     runs-on: ubuntu-latest
 
-    strategy:
-
-      matrix:
-        python-version: ["{{ cookiecutter.python_version }}"]
-      fail-fast: false
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-        uses: actions/setup-python@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
-          python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          node-version: 16
 
-      - name: Cache Python environment
-        uses: actions/cache@v3
-        with:
-          path: .venv/
-          key: {% raw %}venv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}{% endraw %}
+      - name: Install @devcontainers/cli
+        run: npm install --location=global @devcontainers/cli
 
-      - name: Install Poetry
-        run: pip install --no-input poetry
-
-      - name: Install Python environment
+      - name: Start Dev Container
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
-          {%- if cookiecutter.private_package_repository_name %}
-          poetry config http-basic.{{ cookiecutter.private_package_repository_name|slugify }} "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_USERNAME }}" "{% raw %}${{{% endraw %} secrets.POETRY_HTTP_BASIC_{{ cookiecutter.private_package_repository_name|slugify|upper|replace("-", "_") }}_PASSWORD }}"
-          {%- endif %}
-          poetry config virtualenvs.in-project true
-          poetry install --no-interaction
+          git config --global init.defaultBranch main
+          devcontainer up --workspace-folder .
 
-      - name: Lint
-        run: poetry run poe lint
+      - name: Lint package
+        run: devcontainer exec --workspace-folder . poe lint
 
-      - name: Test
-        run: poetry run poe test
+      - name: Test package
+        run: devcontainer exec --workspace-folder . poe test
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}deploy.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}deploy.yml{% endif %}
@@ -20,25 +20,22 @@ on:
 
 env:
   DEFAULT_DEPLOYMENT_ENVIRONMENT: feature
-  REGISTRY: ghcr.io
+  DOCKER_REGISTRY: ghcr.io
 
 jobs:
-
   deploy:
-
     runs-on: ubuntu-latest
 
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Log in to the Docker registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
-          registry: {% raw %}${{ env.REGISTRY }}{% endraw %}
+          registry: {% raw %}${{ env.DOCKER_REGISTRY }}{% endraw %}
           username: {% raw %}${{ github.actor }}{% endraw %}
           password: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
@@ -46,7 +43,7 @@ jobs:
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             SOURCE_BRANCH={% raw %}${{ env.GITHUB_REF }}{% endraw %}
@@ -61,6 +58,6 @@ jobs:
             "
           {%- endif %}
           tags: |
-            {% raw %}${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ github.repository }}:${{ github.event.inputs.environment || env.DEFAULT_DEPLOYMENT_ENVIRONMENT }}{% endraw %}
-            {% raw %}${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ github.repository }}:${{ env.GIT_TAG }}{% endraw %}
+            {% raw %}${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ github.repository }}:${{ github.event.inputs.environment || env.DEFAULT_DEPLOYMENT_ENVIRONMENT }}{% endraw %}
+            {% raw %}${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ github.repository }}:${{ env.GIT_TAG }}{% endraw %}
           target: app

--- a/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if not cookiecutter.with_fastapi_api|int and not cookiecutter.with_streamlit_app|int %}publish.yml{% endif %}
+++ b/{{ cookiecutter.package_name|slugify }}/.github/workflows/{% if not cookiecutter.with_fastapi_api|int and not cookiecutter.with_streamlit_app|int %}publish.yml{% endif %}
@@ -6,18 +6,15 @@ on:
       - created
 
 jobs:
-
   publish:
-
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "{{ cookiecutter.python_version }}"
 

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -30,64 +30,64 @@ version_files = ["pyproject.toml:version"]
 [tool.poetry.dependencies]
 {%- if cookiecutter.with_fastapi_api|int %}
 coloredlogs = "^15.0.1"
-fastapi = "^0.76.0"
+fastapi = "^0.78.0"
 gunicorn = "^20.1.0"
 {%- endif %}
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
-poethepoet = "^0.13.1"
+poethepoet = "^0.14.0"
 {%- endif %}
 python = "^{{ cookiecutter.python_version }}"
 {%- if cookiecutter.with_pydantic_typing|int %}
-pydantic = "^1.9.0"
+pydantic = "^1.9.1"
 {%- endif %}
 {%- if cookiecutter.with_sentry_logging|int %}
-sentry-sdk = "^1.5.11"
+sentry-sdk = "^1.6.0"
 {%- endif %}
 {%- if cookiecutter.with_streamlit_app|int %}
-streamlit = "^1.9.0"
+streamlit = "^1.10.0"
 {%- endif %}
 {%- if cookiecutter.with_typer_cli|int %}
 typer = "^0.4.1"
 {%- endif %}
 {%- if cookiecutter.with_fastapi_api|int %}
-uvicorn = { extras = ["standard"], version = "^0.17.6" }
+uvicorn = { extras = ["standard"], version = "^0.18.2" }
 {%- endif %}
 
 # https://python-poetry.org/docs/master/managing-dependencies/
 # TODO: Split in `tool.poetry.group.dev` and `tool.poetry.group.test` when Poetry 1.2.0 is released.
 [tool.poetry.dev-dependencies]
-black = "^22.3.0"
-commitizen = "^2.24.0"
-coverage = { extras = ["toml"], version = "^6.3.2" }
+black = "^22.6.0"
+commitizen = "^2.27.1"
+coverage = { extras = ["toml"], version = "^6.4.1" }
 cruft = "^2.10.2"
 darglint = "^1.8.1"
 flake8 = "^4.0.1"
 flake8-bandit = "^3.0.0"
-flake8-bugbear = "^22.4.25"
-flake8-comprehensions = "^3.8.0"
+flake8-bugbear = "^22.6.22"
+flake8-comprehensions = "^3.10.0"
 flake8-mutable = "^1.2.0"
 flake8-print = "^5.0.0"
 flake8-pytest-style = "^1.6.0"
-flake8-rst-docstrings = "^0.2.5"
-flake8-tidy-imports = "^4.7.0"
+flake8-rst-docstrings = "^0.2.6"
+flake8-tidy-imports = "^4.8.0"
 flake8-use-fstring = "^1.3"
 isort = "^5.10.1"
 {%- if cookiecutter.with_jupyter_lab|int %}
-jupyterlab = "^3.4.0"
+jupyterlab = "^3.4.3"
 {%- endif %}
-mypy = "^0.950"
-pdoc = "^11.2.0"
-pep8-naming = "^0.12.1"
+mypy = "^0.961"
+pdoc = "^12.0.2"
+pep8-naming = "^0.13.0"
 {%- if not cookiecutter.with_fastapi_api|int and not cookiecutter.with_streamlit_app|int %}
-poethepoet = "^0.13.1"
+poethepoet = "^0.14.0"
 {%- endif %}
 pre-commit = "^2.19.0"
 pydocstyle = { extras = ["toml"], version = "^6.1.1" }
 pytest = "^7.1.2"
 pytest-clarity = "^1.0.1"
-pytest-mock = "^3.7.0"
+pytest-mock = "^3.8.1"
 pytest-xdist = "^2.5.0"
-pyupgrade = "^2.32.1"
+pyupgrade = "^2.34.0"
 safety = "^1.10.3"
 shellcheck-py = "^0.8.0"
 {%- if cookiecutter.private_package_repository_name %}


### PR DESCRIPTION
Uses the new [devcontainers/ci](https://github.com/devcontainers/ci) GitHub Action to test the Dev Container directly, instead of creating a local Python environment as we do now.

EDIT: Because of https://github.com/devcontainers/ci/issues/148, we'll use the devcontainers CLI instead.