### PR TITLE
feat: upgrade typer with rich

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -59,7 +59,7 @@ uvicorn = { extras = ["standard"], version = "^0.18.2" }
 black = "^22.6.0"
 commitizen = "^2.27.1"
 coverage = { extras = ["toml"], version = "^6.4.1" }
-cruft = "^2.10.2"
+cruft = "^2.11.0"
 darglint = "^1.8.1"
 flake8 = "^4.0.1"
 flake8-bandit = "^3.0.0"

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -47,7 +47,7 @@ sentry-sdk = "^1.6.0"
 streamlit = "^1.10.0"
 {%- endif %}
 {%- if cookiecutter.with_typer_cli|int %}
-typer = "^0.4.1"
+typer = { extras = ["all"], version = "^0.6.1" }
 {%- endif %}
 {%- if cookiecutter.with_fastapi_api|int %}
 uvicorn = { extras = ["standard"], version = "^0.18.2" }


### PR DESCRIPTION
From [1]:
> The biggest Typer release in a long time 🤯🎉
> 
> Deep integration with [@textualizeio](https://twitter.com/textualizeio) ([@willmcgugan](https://twitter.com/willmcgugan)) Rich 💰🎨
> 
> Still optional, but if you install Rich, or:
> 
> pip install "typer[all]"
> 
> ...your app will shine, by default ✨
> 
> Go get version 0.6.1 (a quick bug fix on top of 0.6.0) 🔖

[1] https://twitter.com/tiangolo/status/1546961217251590145?s=20&t=5Uf1d8_HC0Mf-694QMn7bg