### PR TITLE
feat: improve secrets mounting

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "workspaceFolder": "/app/",
     "initializeCommand": "ssh-add --apple-load-keychain || true",
     "overrideCommand": true,
-    "postStartCommand": "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/{% if cookiecutter.private_package_repository_name %} && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml{% endif %}",
+    "postStartCommand": "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/{{ cookiecutter.package_name|slugify }}/Dockerfile
+++ b/{{ cookiecutter.package_name|slugify }}/Dockerfile
@@ -66,6 +66,11 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
     echo 'antigen apply' >> ~/.zshrc && \
     echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
     zsh -c 'source ~/.zshrc'
+{%- if cookiecutter.private_package_repository_name %}
+
+# Enable Poetry to read the private package repository credentials.
+RUN ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml
+{%- endif %}
 
 # Persist output generated during docker build so that we can restore it in the dev container.
 COPY .pre-commit-config.yaml /app/

--- a/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
+++ b/{{ cookiecutter.package_name|slugify }}/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       [
         "sh",
         "-c",
-        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/{% if cookiecutter.private_package_repository_name %} && ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml{% endif %} && zsh"
+        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/ && zsh"
       ]
     environment:
       {%- if not cookiecutter.private_package_repository_name %}
@@ -58,7 +58,7 @@ services:
 
 secrets:
   poetry_auth:
-    file: $POETRY_AUTH_TOML_PATH
+    file: "${POETRY_AUTH_TOML_PATH:-~/Library/Application Support/pypoetry/auth.toml}"
 {%- endif %}
 
 volumes:


### PR DESCRIPTION
This PR brings two improvements:
1. After this PR, the Dev Container's `auth.toml` is loaded properly even if you override the docker compose command. Before this PR, if you use a different command then `auth.toml` would not be available in the container.
2. We set a default for `POETRY_AUTH_TOML_PATH` in `docker-compose.yml` so that you can skip setting that variable if you are on macOS. Other environments will still need to set that variable if the project uses a private package repository.