### PR TITLE
feat: upgrade linters

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.package_name|slugify }}/.devcontainer/devcontainer.json
@@ -31,10 +31,14 @@
                 "files.autoSave": "onFocusChange",
                 "python.defaultInterpreterPath": "/opt/app-env/bin/python",
                 "python.formatting.provider": "black",
+                "python.linting.banditArgs": [
+                    "--configfile",
+                    "pyproject.toml"
+                ],
+                "python.linting.banditEnabled": true,
                 "python.linting.flake8Enabled": true,
                 "python.linting.mypyEnabled": true,
                 "python.linting.pydocstyleEnabled": true,
-                "python.linting.pylintEnabled": false,
                 "python.terminal.activateEnvironment": false,
                 "python.testing.pytestEnabled": true,
                 "terminal.integrated.defaultProfile.linux": "zsh",

--- a/{{ cookiecutter.package_name|slugify }}/.flake8
+++ b/{{ cookiecutter.package_name|slugify }}/.flake8
@@ -4,7 +4,7 @@
 # TODO: https://github.com/PyCQA/flake8/issues/234
 color = always
 doctests = True
-ignore = DAR103,E203,E501,FS003,S101,W503
+ignore = DAR103,E203,E501,S101,W503
 max_line_length = 100
 max_complexity = 10
 

--- a/{{ cookiecutter.package_name|slugify }}/.flake8
+++ b/{{ cookiecutter.package_name|slugify }}/.flake8
@@ -4,7 +4,7 @@
 # TODO: https://github.com/PyCQA/flake8/issues/234
 color = always
 doctests = True
-ignore = DAR103,E203,E501,S101,W503
+ignore = DAR103,E203,E501,W503
 max_line_length = 100
 max_complexity = 10
 

--- a/{{ cookiecutter.package_name|slugify }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name|slugify }}/.pre-commit-config.yaml
@@ -72,14 +72,19 @@ repos:
         entry: shellcheck --check-sourced
         language: system
         types: [shell]
-      - id: flake8
-        name: flake8
-        entry: flake8
+      - id: bandit
+        name: bandit
+        entry: bandit --configfile pyproject.toml
         language: system
         types: [python]
       - id: pydocstyle
         name: pydocstyle
         entry: pydocstyle
+        language: system
+        types: [python]
+      - id: flake8
+        name: flake8
+        entry: flake8
         language: system
         types: [python]
       - id: poetry-check

--- a/{{ cookiecutter.package_name|slugify }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name|slugify }}/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-ast

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -62,7 +62,7 @@ commitizen = "^2.27.1"
 coverage = { extras = ["toml"], version = "^6.4.1" }
 cruft = "^2.11.0"
 darglint = "^1.8.1"
-flake8 = "^5.0.2"
+flake8 = "^5.0.4"
 flake8-bugbear = "^22.6.22"
 flake8-comprehensions = "^3.10.0"
 flake8-mutable = "^1.2.0"

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -56,13 +56,13 @@ uvicorn = { extras = ["standard"], version = "^0.18.2" }
 # https://python-poetry.org/docs/master/managing-dependencies/
 # TODO: Split in `tool.poetry.group.dev` and `tool.poetry.group.test` when Poetry 1.2.0 is released.
 [tool.poetry.dev-dependencies]
+bandit = { extras = ["toml"], version = "^1.7.4" }
 black = "^22.6.0"
 commitizen = "^2.27.1"
 coverage = { extras = ["toml"], version = "^6.4.1" }
 cruft = "^2.11.0"
 darglint = "^1.8.1"
 flake8 = "^5.0.2"
-flake8-bandit = "^3.0.0"
 flake8-bugbear = "^22.6.22"
 flake8-comprehensions = "^3.10.0"
 flake8-mutable = "^1.2.0"
@@ -96,6 +96,10 @@ shellcheck-py = "^0.8.0"
 name = "{{ cookiecutter.private_package_repository_name|slugify }}"
 url = "{{ cookiecutter.private_package_repository_url }}"
 {%- endif %}
+
+# https://bandit.readthedocs.io/en/latest/config.html
+[tool.bandit]
+skips = ["B101"]
 
 # https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file
 [tool.black]

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -61,7 +61,7 @@ commitizen = "^2.27.1"
 coverage = { extras = ["toml"], version = "^6.4.1" }
 cruft = "^2.11.0"
 darglint = "^1.8.1"
-flake8 = "^4.0.1"
+flake8 = "^5.0.2"
 flake8-bandit = "^3.0.0"
 flake8-bugbear = "^22.6.22"
 flake8-comprehensions = "^3.10.0"
@@ -70,7 +70,6 @@ flake8-print = "^5.0.0"
 flake8-pytest-style = "^1.6.0"
 flake8-rst-docstrings = "^0.2.6"
 flake8-tidy-imports = "^4.8.0"
-flake8-use-fstring = "^1.3"
 isort = "^5.10.1"
 {%- if cookiecutter.with_jupyter_lab|int %}
 jupyterlab = "^3.4.3"
@@ -88,7 +87,7 @@ pytest-clarity = "^1.0.1"
 pytest-mock = "^3.8.1"
 pytest-xdist = "^2.5.0"
 pyupgrade = "^2.34.0"
-safety = "^1.10.3"
+safety = "^2.1.1"
 shellcheck-py = "^0.8.0"
 {%- if cookiecutter.private_package_repository_name %}
 
@@ -231,7 +230,7 @@ xfail_strict = true
       """
 
     [[tool.poe.tasks.lint.sequence]]
-    shell = "safety check --full-report || true"
+    shell = "safety check --continue-on-error --full-report"
 {%- if cookiecutter.with_fastapi_api|int %}
 
   [tool.poe.tasks.serve]


### PR DESCRIPTION
Changes:
- Removed `flake8-use-fstring` (and `FS003`) in favour of `pyupgrade`
- Upgrade `pre-commit-hooks` from v4.1.0 to v4.3.0
- Upgrade `flake8` from v4.0.1 to v5.0.4
- Upgrade `safety` from v1.10.3 to v2.1.1 and simplify `poe lint` with it
- Replace `flake8-bandit` with `bandit` (because of https://github.com/tylerwince/flake8-bandit/issues/33)