### PR TITLE
ci: remove superfluous Dependabot scope

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.github/dependabot.yml
+++ b/{{ cookiecutter.package_name|slugify }}/.github/dependabot.yml
@@ -6,16 +6,16 @@ updates:
     schedule:
       interval: monthly
     commit-message:
-      prefix: "ci(deps)"
-      prefix-development: "ci(deps)"
+      prefix: "ci"
+      prefix-development: "ci"
       include: "scope"
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: monthly
     commit-message:
-      prefix: "build(deps)"
-      prefix-development: "build(deps)"
+      prefix: "build"
+      prefix-development: "build"
       include: "scope"
     versioning-strategy: lockfile-only
     allow:


### PR DESCRIPTION
Dependabot already adds a scope to the commit prefix, so no need for us to specify one:
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/4543654/182606211-6312b72c-a621-443a-a4a0-c120a7d3a308.png">
