### PR TITLE
feat: improve flake8, isort, and pytest config

### DIFF
--- a/{{ cookiecutter.package_name|slugify }}/.flake8
+++ b/{{ cookiecutter.package_name|slugify }}/.flake8
@@ -2,6 +2,7 @@
 # http://flake8.pycqa.org/en/latest/user/configuration.html#project-configuration
 # https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
 # TODO: https://github.com/PyCQA/flake8/issues/234
+color = always
 doctests = True
 ignore = DAR103,E203,E501,FS003,S101,W503
 max_line_length = 100

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -112,7 +112,7 @@ skip_covered = true
 # https://coverage.readthedocs.io/en/latest/config.html#run
 [tool.coverage.run]
 branch = true
-command_line = "--module pytest src tests"
+command_line = "--module pytest"
 data_file = "reports/.coverage"
 source = ["src"]
 
@@ -157,9 +157,10 @@ convention = "{{ cookiecutter.docstring_style|lower }}"
 
 # https://docs.pytest.org/en/latest/customize.html#adding-default-options
 [tool.pytest.ini_options]
-addopts = "-W error -W ignore::DeprecationWarning --doctest-modules --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"
-junit_family = "xunit2"
-testpaths = "tests"
+addopts = "--doctest-modules --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"
+filterwarnings = ["error", "ignore::DeprecationWarning"]
+testpaths = ["src", "tests"]
+xfail_strict = "True"
 
 # https://github.com/nat-n/poethepoet
 [tool.poe.tasks]

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -120,11 +120,12 @@ source = ["src"]
 [tool.coverage.xml]
 output = "reports/coverage.xml"
 
-# https://pycqa.github.io/isort/docs/configuration/profiles/
+# https://pycqa.github.io/isort/docs/configuration/options.html
 [tool.isort]
-known_first_party = "tests"
+color = true
 line_length = 100
 profile = "black"
+src_paths = ["src", "tests"]
 
 # https://mypy.readthedocs.io/en/latest/config_file.html
 [tool.mypy]
@@ -155,9 +156,9 @@ warn_untyped_fields = true
 [tool.pydocstyle]
 convention = "{{ cookiecutter.docstring_style|lower }}"
 
-# https://docs.pytest.org/en/latest/customize.html#adding-default-options
+# https://docs.pytest.org/en/latest/reference/reference.html#ini-options-ref
 [tool.pytest.ini_options]
-addopts = "--doctest-modules --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"
+addopts = "--color=yes --doctest-modules --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 testpaths = ["src", "tests"]
 xfail_strict = "True"

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -161,7 +161,7 @@ convention = "{{ cookiecutter.docstring_style|lower }}"
 addopts = "--color=yes --doctest-modules --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 testpaths = ["src", "tests"]
-xfail_strict = "True"
+xfail_strict = true
 
 # https://github.com/nat-n/poethepoet
 [tool.poe.tasks]

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -122,7 +122,7 @@ output = "reports/coverage.xml"
 
 # https://pycqa.github.io/isort/docs/configuration/options.html
 [tool.isort]
-color = true
+color_output = true
 line_length = 100
 profile = "black"
 src_paths = ["src", "tests"]

--- a/{{ cookiecutter.package_name|slugify }}/pyproject.toml
+++ b/{{ cookiecutter.package_name|slugify }}/pyproject.toml
@@ -105,7 +105,7 @@ line-length = 100
 # https://coverage.readthedocs.io/en/latest/config.html#report
 [tool.coverage.report]
 fail_under = 50
-precision = 2
+precision = 1
 show_missing = true
 skip_covered = true
 


### PR DESCRIPTION
Improvements:
1. Move options from `addopts` to dedicated configuration options [1], if available.
2. Remove `junit_family = "xunit2"`, which is the default since pytest v6.1 [2].
3. Add `xfail_strict = true` to make tests that are marked to expect to fail but actually pass, to fail.
4. Add `src` to the `testpaths` so that doctests are automatically executed as well when you run `pytest`. This also allows us to not have to explicitly say we want to run tests in `src` and `tests` when using Coverage.py with `poe lint`.
5. Add color output for flake8 (new since v5.0.0), isort, pytest (especially useful in CI where auto-detection fails).
6. Upgrade from `known_first_party` to `src_paths` in isort.
7. Fix URLs to config documentation.

[1] https://docs.pytest.org/en/latest/reference/reference.html#configuration-options
[2] https://docs.pytest.org/en/latest/reference/reference.html#confval-junit_family