### PR TITLE
feat: add Linux support

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "service": "dev",
     "workspaceFolder": "/app/",
     "overrideCommand": true,
-    "postStartCommand": "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/",
+    "postStartCommand": "cp --update /opt/build/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /opt/build/git/* /app/.git/hooks/",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
 FROM python:{{ cookiecutter.python_version }}-slim AS base
 
 # Configure Python to print tracebacks on crash [1], and to not buffer stdout and stderr [2].
@@ -9,59 +9,89 @@ ENV PYTHONUNBUFFERED 1
 
 # Install Poetry.
 ENV POETRY_VERSION 1.1.13
-RUN --mount=type=cache,id=poetry,target=/root/.cache/ pip install poetry==$POETRY_VERSION
+RUN --mount=type=cache,target=/root/.cache/ \
+    pip install poetry==$POETRY_VERSION
 
 # Create and activate a virtual environment.
 RUN python -m venv /opt/app-env
 ENV PATH /opt/app-env/bin:$PATH
 ENV VIRTUAL_ENV /opt/app-env
 
-# Set the working directory.
-WORKDIR /app/
-
-FROM base as deps
-
 # Install compilers that may be required for certain packages or platforms.
 RUN rm /etc/apt/apt.conf.d/docker-clean
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
-    --mount=type=cache,id=apt-lib,target=/var/lib/apt/ \
+RUN --mount=type=cache,target=/var/cache/apt/ \
+    --mount=type=cache,target=/var/lib/apt/ \
     apt-get update && \
     apt-get install --no-install-recommends --yes build-essential
 
+# Set the working directory.
+WORKDIR /app/
+
 # Install the run time Python environment.
 COPY poetry.lock* pyproject.toml /app/
-RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
+RUN --mount=type=cache,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
     --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
     {%- endif %}
     mkdir -p src/{{ cookiecutter.__package_name_snake_case }}/ && touch src/{{ cookiecutter.__package_name_snake_case }}/__init__.py && touch README.md && \
     poetry install --no-dev --no-interaction
 
-FROM deps as ci
+# Create a non-root user.
+ARG UID 1000
+ARG GID $UID
+RUN groupadd --gid $GID app && \
+    useradd --create-home --gid $GID --uid $UID app
+
+FROM base as ci
 
 # Install git so we can run pre-commit.
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
-    --mount=type=cache,id=apt-lib,target=/var/lib/apt/ \
+RUN --mount=type=cache,target=/var/cache/apt/ \
+    --mount=type=cache,target=/var/lib/apt/ \
     apt-get update && \
     apt-get install --no-install-recommends --yes git
 
 # Install the development Python environment.
-RUN --mount=type=cache,id=poetry,target=/root/.cache/ \
+RUN --mount=type=cache,target=/root/.cache/ \
     {%- if cookiecutter.private_package_repository_name %}
     --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
     {%- endif %}
     poetry install --no-interaction
 
-FROM ci as dev
+# Give the non-root user ownership and switch to the non-root user.
+RUN chown --recursive app /app/ /opt/
+USER app
 
-# Install development tools: compilers, curl, git, gpg, ssh, starship, vim, and zsh.
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
-    --mount=type=cache,id=apt-lib,target=/var/lib/apt/ \
+FROM base as dev
+
+# Install development tools: compilers, curl, git, gpg, ssh, starship, sudo, vim, and zsh.
+RUN --mount=type=cache,target=/var/cache/apt/ \
+    --mount=type=cache,target=/var/lib/apt/ \
     apt-get update && \
-    apt-get install --no-install-recommends --yes build-essential curl git gnupg ssh vim zsh zsh-antigen && \
-    chsh --shell /usr/bin/zsh && \
+    apt-get install --no-install-recommends --yes build-essential curl git gnupg ssh sudo vim zsh zsh-antigen && \
     sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- "--yes" && \
-    echo 'source /usr/share/zsh-antigen/antigen.zsh' >> ~/.zshrc && \
+    usermod --shell /usr/bin/zsh app
+
+# Install the development Python environment.
+RUN --mount=type=cache,target=/root/.cache/ \
+    {%- if cookiecutter.private_package_repository_name %}
+    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
+    {%- endif %}
+    poetry install --no-interaction
+
+# Persist output generated during docker build so that we can restore it in the dev container.
+COPY .pre-commit-config.yaml /app/
+RUN mkdir -p /opt/build/poetry/ && cp poetry.lock /opt/build/poetry/ && \
+    git init && pre-commit install --install-hooks && \
+    mkdir -p /opt/build/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /opt/build/git/
+
+# Give the non-root user ownership and switch to the non-root user.
+RUN chown --recursive app /app/ /opt/ && \
+    echo 'app ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/app && \
+    chmod 0440 /etc/sudoers.d/app
+USER app
+
+# Configure the non-root user's shell.
+RUN echo 'source /usr/share/zsh-antigen/antigen.zsh' >> ~/.zshrc && \
     echo 'antigen bundle zsh-users/zsh-syntax-highlighting' >> ~/.zshrc && \
     echo 'antigen bundle zsh-users/zsh-autosuggestions' >> ~/.zshrc && \
     echo 'antigen apply' >> ~/.zshrc && \
@@ -71,20 +101,18 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt/ \
 {%- if cookiecutter.private_package_repository_name %}
 
 # Enable Poetry to read the private package repository credentials.
-RUN ln -s /run/secrets/poetry_auth /root/.config/pypoetry/auth.toml
+RUN mkdir -p ~/.config/pypoetry/ && ln -s /run/secrets/poetry_auth ~/.config/pypoetry/auth.toml
 {%- endif %}
-
-# Persist output generated during docker build so that we can restore it in the dev container.
-COPY .pre-commit-config.yaml /app/
-RUN mkdir -p /var/lib/poetry/ && cp poetry.lock /var/lib/poetry/ && \
-    git init && pre-commit install --install-hooks && \
-    mkdir -p /var/lib/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /var/lib/git/
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
 
-FROM deps AS app
+FROM base AS app
 
 # Copy the package source code to the working directory.
-COPY src/ *.py /app/
+COPY . .
+
+# Give the non-root user ownership and switch to the non-root user.
+RUN chown --recursive app /app/ /opt/
+USER app
 
 # Expose the application.
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}

--- a/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
@@ -37,8 +37,8 @@ RUN --mount=type=cache,target=/root/.cache/ \
     poetry install --no-dev --no-interaction
 
 # Create a non-root user.
-ARG UID 1000
-ARG GID $UID
+ARG UID=1000
+ARG GID=$UID
 RUN groupadd --gid $GID app && \
     useradd --create-home --gid $GID --uid $UID app
 

--- a/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
@@ -96,7 +96,7 @@ RUN echo 'source /usr/share/zsh-antigen/antigen.zsh' >> ~/.zshrc && \
     echo 'antigen bundle zsh-users/zsh-autosuggestions' >> ~/.zshrc && \
     echo 'antigen apply' >> ~/.zshrc && \
     echo 'eval "$(starship init zsh)"' >> ~/.zshrc && \
-    echo 'HISTFILE=/opt/app-env/.zsh_history' >> ~/.zshrc && \
+    echo 'HISTFILE=~/.zsh_history' >> ~/.zshrc && \
     zsh -c 'source ~/.zshrc'
 {%- if cookiecutter.private_package_repository_name %}
 

--- a/{{ cookiecutter.__package_name_kebab_case }}/README.md
+++ b/{{ cookiecutter.__package_name_kebab_case }}/README.md
@@ -66,7 +66,25 @@ To serve this app, run `docker compose up app` and open [localhost:8000](http://
 {%- endif %}
 1. [Install Docker Desktop](https://www.docker.com/get-started).
     - Enable _Use Docker Compose V2_ in Docker Desktop's preferences window.
-    - If you are using Linux, you must [configure Docker and Docker Compose to use the BuildKit build system](https://pythonspeed.com/articles/docker-buildkit/). On macOS and Windows, BuildKit is enabled by default in Docker Desktop.
+    - _Linux only_:
+        - [Configure Docker and Docker Compose to use the BuildKit build system](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds). On macOS and Windows, BuildKit is enabled by default in Docker Desktop.
+        - Export your user's user id and group id so that [files created in the Dev Container are owned by your user](https://github.com/moby/moby/issues/3206):
+            ```sh
+            cat << EOF >> ~/.bashrc
+            export UID=$(id --user)
+            export GID=$(id --group)
+            {%- if cookiecutter.private_package_repository_name %}
+            export POETRY_AUTH_TOML_PATH="~/.config/pypoetry/auth.toml"
+            {%- endif %}
+            EOF
+            ```
+    {%- if cookiecutter.private_package_repository_name %}
+    - _Windows only_:
+        - Export the location of your private package repository credentials so that Docker Compose can load these as a [build and run time secret](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets-configuration-reference):
+            ```bat
+            setx POETRY_AUTH_TOML_PATH %APPDATA%\pypoetry\auth.toml
+            ```
+    {%- endif %}
 1. [Install VS Code](https://code.visualstudio.com/) and [VS Code's Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Alternatively, install [PyCharm](https://www.jetbrains.com/pycharm/download/).
     - _Optional:_ Install a [Nerd Font](https://www.nerdfonts.com/font-downloads) such as [FiraCode Nerd Font](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/FiraCode) with `brew tap homebrew/cask-fonts && brew install --cask font-fira-code-nerd-font` and [configure VS Code](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions) or [configure PyCharm](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions) to use `'FiraCode Nerd Font'`.
 
@@ -76,20 +94,7 @@ To serve this app, run `docker compose up app` and open [localhost:8000](http://
 <summary>Setup: once per project</summary>
 
 1. Clone this repository.
-{%- if cookiecutter.private_package_repository_name %}
-1. Create a `.env` file in the project directory that [Docker Compose reads](https://docs.docker.com/compose/env-file/) to use Poetry's `auth.toml` file as a [build and run time secret](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets-configuration-reference):
-    ```sh
-    # Linux
-    POETRY_AUTH_TOML_PATH="~/.config/pypoetry/auth.toml"
-
-    # macOS
-    POETRY_AUTH_TOML_PATH="~/Library/Application Support/pypoetry/auth.toml"
-
-    # Windows
-    POETRY_AUTH_TOML_PATH="$APPDATA/pypoetry/auth.toml"
-    ```
-{%- endif %}
-1. Start a [Dev Container](https://code.visualstudio.com/docs/remote/containers) in your preferred development environment:
+2. Start a [Dev Container](https://code.visualstudio.com/docs/remote/containers) in your preferred development environment:
     - _VS Code_: open the cloned repository and run <kbd>Ctrl/⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd> → _Remote-Containers: Reopen in Container_.
     - _PyCharm_: open the cloned repository and [configure Docker Compose as a remote interpreter](https://www.jetbrains.com/help/pycharm/using-docker-compose-as-a-remote-interpreter.html#docker-compose-remote).
     - _Terminal_: open the cloned repository and run `docker compose run --rm dev` to start an interactive Dev Container.

--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       secrets:
         - poetry_auth
       {%- endif %}
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     stdin_open: true
     tty: true
     entrypoint: []
@@ -16,7 +19,7 @@ services:
       [
         "sh",
         "-c",
-        "cp --update /var/lib/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /var/lib/git/* /app/.git/hooks/ && zsh"
+        "cp --update /opt/build/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /opt/build/git/* /app/.git/hooks/ && zsh"
       ]
     environment:
       {%- if not cookiecutter.private_package_repository_name %}
@@ -33,9 +36,8 @@ services:
     {%- endif %}
     volumes:
       - .:/app/
-      - app-env:/opt/app-env/
       - ~/.gitconfig:/etc/gitconfig
-      - ~/.ssh/known_hosts:/root/.ssh/known_hosts
+      - ~/.ssh/known_hosts:/home/app/.ssh/known_hosts
       - ${SSH_AGENT_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/run/host-services/ssh-auth.sock
   {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   app:
@@ -60,6 +62,3 @@ secrets:
   poetry_auth:
     file: "${POETRY_AUTH_TOML_PATH:-~/Library/Application Support/pypoetry/auth.toml}"
 {%- endif %}
-
-volumes:
-  app-env:


### PR DESCRIPTION
Before this PR, Linux support was not great:
1. Within the Dev Container, you are `root`.
2. All files created by you in the Dev Container are therefore owned by `root` in the container.
3. On Linux, files you create within the Dev Container in a (bind-)mounted volume are unfortunately then also owned by `root` on the host system [1]. The result is that you cannot edit those files later on.

This PR brings Linux support to the same level as macOS by introducing a new user that has the same user id and group id as your user on the host machine. This addresses the ownership issue above, and is also better for security as the application won't run as a privileged user [2].

[1] https://github.com/moby/moby/issues/3206
[2] https://pythonspeed.com/articles/root-capabilities-docker-security/