### PR TITLE
fix: fix ssh agent forwarding on macOS

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       [
         "sh",
         "-c",
-        "cp --update /opt/build/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /opt/build/git/* /app/.git/hooks/ && zsh"
+        "sudo chown app $$SSH_AUTH_SOCK && cp --update /opt/build/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /opt/build/git/* /app/.git/hooks/ && zsh"
       ]
     environment:
       {%- if not cookiecutter.private_package_repository_name %}


### PR DESCRIPTION
Problem [1]:
1. We need to use a non-root user in the container so that files written on Linux are owned by the host's user instead of root.
2. [The Docker for Mac docs explain that you need to mount `/run/host-services/ssh-auth.sock` to forward the host's SSH agent](https://docs.docker.com/desktop/networking/#ssh-agent-forwarding).
3. Docker for Mac will mount that socket as root, which means that the non-root container user doesn't have permission to use the mounted SSH agent socket.

Solution: on startup, we `chown` the socket to the non-root user `app`.

[1] https://github.com/docker/for-mac/issues/5303#issuecomment-1009003400