### PR TITLE
feat: support GitHub Codespaces

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "{{ cookiecutter.__package_name_kebab_case }}",
     "dockerComposeFile": "../docker-compose.yml",
-    "service": "dev",
+    "service": "devcontainer",
     "workspaceFolder": "/app/",
     "overrideCommand": true,
     "postStartCommand": "cp --update /opt/build/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /opt/build/git/* /app/.git/hooks/",

--- a/{{ cookiecutter.__package_name_kebab_case }}/README.md
+++ b/{{ cookiecutter.__package_name_kebab_case }}/README.md
@@ -96,7 +96,7 @@ To serve this app, run `docker compose up app` and open [localhost:8000](http://
 1. Clone this repository.
 2. Start a [Dev Container](https://code.visualstudio.com/docs/remote/containers) in your preferred development environment:
     - _VS Code_: open the cloned repository and run <kbd>Ctrl/⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd> → _Remote-Containers: Reopen in Container_.
-    - _PyCharm_: open the cloned repository and [configure Docker Compose as a remote interpreter](https://www.jetbrains.com/help/pycharm/using-docker-compose-as-a-remote-interpreter.html#docker-compose-remote).
+    - _PyCharm_: open the cloned repository and select the `dev` service when [configuring Docker Compose as a remote interpreter](https://www.jetbrains.com/help/pycharm/using-docker-compose-as-a-remote-interpreter.html#docker-compose-remote).
     - _Terminal_: open the cloned repository and run `docker compose run --rm dev` to start an interactive Dev Container.
 
 </details>

--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 services:
-  dev:
+  devcontainer:
     build:
       context: .
       target: dev
@@ -13,6 +13,17 @@ services:
         PYTHON_VERSION: ${PYTHON_VERSION:-{{ cookiecutter.python_version }}}
         UID: ${UID:-1000}
         GID: ${GID:-1000}
+    {%- if not cookiecutter.private_package_repository_name %}
+    environment:
+      - POETRY_PYPI_TOKEN_PYPI
+    {%- else %}
+    secrets:
+      - poetry_auth
+    {%- endif %}
+    volumes:
+      - .:/app/
+  dev:
+    extends: devcontainer
     stdin_open: true
     tty: true
     entrypoint: []
@@ -30,10 +41,6 @@ services:
     {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
     ports:
       - "8000"
-    {%- endif %}
-    {%- if cookiecutter.private_package_repository_name %}
-    secrets:
-      - poetry_auth
     {%- endif %}
     volumes:
       - .:/app/


### PR DESCRIPTION
Problem: before this PR, GitHub Codespaces starts up, but is not usable because the `dev` service mounts the host's `~/.gitconfig` and `~/.ssh/known_hosts`, which are not available on GitHub Codespaces and so instead you see them mounted as empty directories in the dev container.

Solution: the solution is to have separate `devcontainer` service in the `docker-compose.yml` that minimally configures the service for a real Dev Container, and then to have a `dev` service that extends the `devcontainer` service and adds additional configuration that is necessary if you run it as a regular container without the Dev Container conveniences (such as .gitconfig, known_hosts, and forwarding the host's SSH agent).