### PR TITLE
fix: remove python-no-eval hook

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
       - id: python-check-blanket-type-ignore
       {%- endif %}
       - id: python-check-mock-methods
-      - id: python-no-eval
       - id: python-no-log-warn
       - id: python-use-type-annotations
       - id: rst-backticks


### PR DESCRIPTION
This PR removes the `python-no-eval` hook because of false positives caused by PyTorch [1].

Closes #126.

[1]  https://github.com/pre-commit/pygrep-hooks/pull/103