### PR TITLE
fix: fix Docker secret mounting

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /app/
 COPY poetry.lock* pyproject.toml /app/
 RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/app/.cache/pypoetry/ \
     {%- if cookiecutter.private_package_repository_name %}
-    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
+    --mount=type=secret,id=poetry_auth,uid=$UID,gid=$GID,target=/home/app/.config/pypoetry/auth.toml \
     {%- endif %}
     mkdir -p src/{{ cookiecutter.__package_name_snake_case }}/ && touch src/{{ cookiecutter.__package_name_snake_case }}/__init__.py && touch README.md && \
     poetry install --only main --no-interaction
@@ -63,7 +63,7 @@ USER app
 # Install the CI/CD Python dependencies in the virtual environment.
 RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/app/.cache/pypoetry/ \
     {%- if cookiecutter.private_package_repository_name %}
-    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
+    --mount=type=secret,id=poetry_auth,uid=$UID,gid=$GID,target=/home/app/.config/pypoetry/auth.toml \
     {%- endif %}
     poetry install --only main,test --no-interaction
 
@@ -84,7 +84,7 @@ USER app
 # Install the development Python dependencies in the virtual environment.
 RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/app/.cache/pypoetry/ \
     {%- if cookiecutter.private_package_repository_name %}
-    --mount=type=secret,id=poetry_auth,target=/root/.config/pypoetry/auth.toml \
+    --mount=type=secret,id=poetry_auth,uid=$UID,gid=$GID,target=/home/app/.config/pypoetry/auth.toml \
     {%- endif %}
     poetry install --no-interaction
 


### PR DESCRIPTION
We forgot to adapt the mounting of Docker secrets after improving the build performance with #137. This PR updates secret mounting so that they are mounted in the right location with the right permissions.