### PR TITLE
fix: explicitly ignore ruff cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ dist/
 __pycache__/
 *.py[cdo]
 
+# Ruff
+.ruff_cache/
+
 # Terraform
 .terraform/
 

--- a/{{ cookiecutter.__package_name_kebab_case }}/.gitignore
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.gitignore
@@ -54,6 +54,9 @@ dist/
 __pycache__/
 *.py[cdo]
 
+# Ruff
+.ruff_cache/
+
 # Terraform
 .terraform/
 


### PR DESCRIPTION
Closes https://github.com/radix-ai/poetry-cookiecutter/issues/154.