### PR TITLE
feat: improve ruff config

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: ruff
         name: ruff
         entry: ruff
-        args: [--fixable F401{% if cookiecutter.development_environment == "simple" %}, --fix-only{% endif %}]
+        args: [--fixable=F401{% if cookiecutter.development_environment == "simple" %}, --fix-only{% endif %}]
         require_serial: true
         language: system
         types: [python]

--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -65,9 +65,7 @@ repos:
       - id: ruff
         name: ruff
         entry: ruff
-        {%- if cookiecutter.development_environment == "simple" %}
-        args: [--fix-only]
-        {%- endif %}
+        args: [--fixable F401{% if cookiecutter.development_environment == "simple" %}, --fix-only{% endif %}]
         require_serial: true
         language: system
         types: [python]

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -70,7 +70,7 @@ pytest = "^7.2.0"
 pytest-clarity = "^1.0.1"
 pytest-mock = "^3.10.0"
 pytest-xdist = "^3.1.0"
-ruff = "^0.0.213"
+ruff = "^0.0.215"
 {%- if cookiecutter.development_environment == "strict" %}
 safety = "^2.3.5"
 shellcheck-py = "^0.9.0"
@@ -150,10 +150,10 @@ ignore-init-module-imports = true
 line-length = 100
 {%- if cookiecutter.development_environment == "strict" %}
 select = ["A", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "ERA", "F", "I", "ISC", "N", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "S", "SIM", "T10", "T20", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "S101"]
+ignore = ["E501", "PGH001", "RET504", "S101"]
 {%- else %}
 select = ["A", "B", "C4", "C90", "D", "DTZ", "E", "F", "I", "ISC", "N", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "SIM", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "PGH002", "PGH003", "S101"]
+ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
 {%- endif %}
 {%- if cookiecutter.docstring_style|lower == "numpy" %}
 extend-ignore = ["D107", "D203", "D212", "D213", "D402", "D413", "D415", "D416", "D417"]
@@ -162,6 +162,7 @@ extend-ignore = ["D203", "D204", "D213", "D215", "D400", "D404", "D406", "D407",
 {%- else %}
 extend-ignore = ["D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "D415", "D416", "D417"]
 {%- endif %}
+unfixable = ["F401"]
 src = ["src", "tests"]
 target-version = "py{{ cookiecutter.python_version|replace('.', '') }}"
 


### PR DESCRIPTION
Changes:
1. Upgrade Ruff to 0.0.215.
2. Ignore RET504: the idea is to remove unnecessary assignments before the return statement. However, we shouldn't be too strict about this as sometimes you do want to add an assignment for clarity.
3. Mark F401 as unfixable: we don't want to auto remove unused imports if you're importing them for the first time. Ruff will continue to mark unused imports as linting issues though.