### PR TITLE
fix: add ruff ignore F841 to prevent removal of unassigned variables

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: ruff
         name: ruff
         entry: ruff
-        args: [--fixable=F401{% if cookiecutter.development_environment == "simple" %}, --fix-only{% endif %}]
+        args: [--fixable=F401,F841{% if cookiecutter.development_environment == "simple" %}, --fix-only{% endif %}]
         require_serial: true
         language: system
         types: [python]

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -150,10 +150,10 @@ ignore-init-module-imports = true
 line-length = 100
 {%- if cookiecutter.development_environment == "strict" %}
 select = ["A", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "ERA", "F", "I", "ISC", "N", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "S", "SIM", "T10", "T20", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "RET504", "S101"]
+ignore = ["E501", "F841", "PGH001", "RET504", "S101"]
 {%- else %}
 select = ["A", "B", "C4", "C90", "D", "DTZ", "E", "F", "I", "ISC", "N", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "SIM", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
+ignore = ["E501", "F841", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
 {%- endif %}
 {%- if cookiecutter.docstring_style|lower == "numpy" %}
 extend-ignore = ["D107", "D203", "D212", "D213", "D402", "D413", "D415", "D416", "D417"]

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -150,10 +150,10 @@ ignore-init-module-imports = true
 line-length = 100
 {%- if cookiecutter.development_environment == "strict" %}
 select = ["A", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "ERA", "F", "I", "ISC", "N", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "S", "SIM", "T10", "T20", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "F841", "PGH001", "RET504", "S101"]
+ignore = ["E501", "PGH001", "RET504", "S101"]
 {%- else %}
 select = ["A", "B", "C4", "C90", "D", "DTZ", "E", "F", "I", "ISC", "N", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "SIM", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "F841", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
+ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
 {%- endif %}
 {%- if cookiecutter.docstring_style|lower == "numpy" %}
 extend-ignore = ["D107", "D203", "D212", "D213", "D402", "D413", "D415", "D416", "D417"]
@@ -162,7 +162,7 @@ extend-ignore = ["D203", "D204", "D213", "D215", "D400", "D404", "D406", "D407",
 {%- else %}
 extend-ignore = ["D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "D415", "D416", "D417"]
 {%- endif %}
-unfixable = ["F401"]
+unfixable = ["F401", "F841"]
 src = ["src", "tests"]
 target-version = "py{{ cookiecutter.python_version|replace('.', '') }}"
 


### PR DESCRIPTION
Prevent unassigned variables from getting removed after saving.