### PR TITLE
fix: update auth.toml location for macOS

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/README.md
+++ b/{{ cookiecutter.__package_name_kebab_case }}/README.md
@@ -38,7 +38,7 @@ To serve this app, run `docker compose up app` and open [localhost:8000](http://
 1. [Create a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) with the `api` scope and use it to [add your private package repository credentials to your Poetry's `auth.toml` file](https://python-poetry.org/docs/repositories/#configuring-credentials):
     ```toml
     # Linux:   ~/.config/pypoetry/auth.toml
-    # macOS:   ~/Library/Application Support/pypoetry/auth.toml
+    # macOS:   ~/Library/Preferences/pypoetry/auth.toml
     # Windows: C:\Users\%USERNAME%\AppData\Roaming\pypoetry\auth.toml
     [http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]
     username = "{personal access token name}"
@@ -60,7 +60,7 @@ To serve this app, run `docker compose up app` and open [localhost:8000](http://
 1. [Add your private package repository credentials to your Poetry's `auth.toml` file](https://python-poetry.org/docs/repositories/#configuring-credentials):
     ```toml
     # Linux:   ~/.config/pypoetry/auth.toml
-    # macOS:   ~/Library/Application Support/pypoetry/auth.toml
+    # macOS:   ~/Library/Preferences/pypoetry/auth.toml
     # Windows: C:\Users\%USERNAME%\AppData\Roaming\pypoetry\auth.toml
     [http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]
     username = "{username}"

--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
 secrets:
   poetry-auth:
-    file: "${POETRY_AUTH_TOML_PATH:-~/Library/Application Support/pypoetry/auth.toml}"
+    file: "${POETRY_AUTH_TOML_PATH:-~/Library/Preferences/pypoetry/auth.toml}"
 {%- endif %}
 
 volumes:


### PR DESCRIPTION
Update the `auth.toml` location for macOS to align with Poetry v1.2.0 and up [1].

[1] https://python-poetry.org/docs/1.2/configuration