### PR TITLE
fix: let Dev Containers manage Docker mounts

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
@@ -92,7 +92,8 @@ RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/app/.cache/pypoetry/ \
 
 # Persist output generated during docker build so that we can restore it in the dev container.
 COPY --chown=app:app .pre-commit-config.yaml /app/
-RUN mkdir -p /opt/build/poetry/ && cp poetry.lock /opt/build/poetry/ && \
+RUN chown app:app opt/ && \
+    mkdir -p /opt/build/poetry/ && cp poetry.lock /opt/build/poetry/ && \
     git init && pre-commit install --install-hooks && \
     mkdir -p /opt/build/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /opt/build/git/
 

--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - poetry-auth
     {%- endif %}
     volumes:
-      - .:/app/
+      - command-history:/home/app/.history/
 
   dev:
     extends: devcontainer
@@ -45,6 +45,7 @@ services:
       - "8000"
     {%- endif %}
     volumes:
+      - .:/app/
       - ~/.gitconfig:/etc/gitconfig
       - ~/.ssh/known_hosts:/home/app/.ssh/known_hosts
       - ${SSH_AGENT_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/run/host-services/ssh-auth.sock


### PR DESCRIPTION
This removes the bind mount from the `devcontainer` Docker Compose service so that the Dev Containers CLI can manage the mounts as it wants to.

Previously, starting a Dev Container by cloning a repo into a (named) Docker volume would lead to a crash. After this PR, this will work as intended. Which also means that the `Open in Dev Containers` badge actually works!