### PR TITLE
fix: enable cloning into Docker volume

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
     "dockerComposeFile": "../docker-compose.yml",
     "service": "devcontainer",
     "workspaceFolder": "/app/",
+    "remoteEnv": {
+        "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+    },
     "remoteUser": "app",
     "overrideCommand": true,
     "postStartCommand": "cp --update /opt/build/poetry/poetry.lock /app/ && mkdir -p /app/.git/hooks/ && cp --update /opt/build/git/* /app/.git/hooks/",

--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - poetry-auth
     {%- endif %}
     volumes:
-      - .:/app/
+      - ${LOCAL_WORKSPACE_FOLDER:-.}:/app/
 
   dev:
     extends: devcontainer


### PR DESCRIPTION
Currently, you cannot use the new [Open in Dev Containers badge](https://github.com/radix-ai/poetry-cookiecutter/pull/165) because the `docker-compose.yml` file tries to mount the current directory, which is not compatible with cloning the repo into a (named) Docker volume first.

To support both use cases (mounting the repo from a local directory, and mounting the repo from a Docker volume), we first expose Dev Container's `localWorkspaceFolder` variable to Docker Compose, and then mount that dynamically [1].

[1] https://stackoverflow.com/questions/60778464/vscode-devcontainer-json-mounts-not-working