### PR TITLE
bugfix: Avoid exploding Docker image size

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__package_name_kebab_case }}/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/var/cache/apt/ \
 ARG UID=1000
 ARG GID=$UID
 RUN groupadd --gid $GID user && \
-    useradd --create-home --gid $GID --uid $UID user && \
+    useradd --create-home --gid $GID --uid $UID user --no-log-init && \
     chown user /opt/
 USER user
 


### PR DESCRIPTION
TLDR: Passing `--no-log-init` to `useradd` prevents an issue where the Docker image size would potentially increase to hundreds of gigabytes when passed a "large" UID or GID. This is apparently a side effect of how `useradd` creates the user fail logs.

The issue is explained in more detail at
https://github.com/docker/docs/issues/4754. The root cause is apparently combination of the following:

1. `useradd` by default allocates space for the faillog and lastlog for "all" users: https://unix.stackexchange.com/q/529827. If you pass it a high UID, e.g. 414053617, it will reserve space for all those 414053617 user logs, which amounts to more than 260GB.
2. The first bullet wouldn't be a problem if Docker would recognize the sparse file and compress it efficiently. However, there is an unresolved issue in the Go archive/tar package's (which Docker uses to package image layers) handling of sparse files:

   https://github.com/golang/go/issues/13548

   Eight years unresolved and counting!

Passing `--no-log-init` to `useradd` avoids allocating space for the faillog and lastlog and fixes the issue.

Finding out the root cause for this bug drove me loco. Reader, enjoy :-)