### PR TITLE
feat: extend Ruff rules and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Starting development in My Package can be done with a single click by [opening M
 - 📦 Packaging and dependency management with [Poetry](https://github.com/python-poetry/poetry)
 - 🚚 Installing from and publishing to private package repositories and [PyPI](https://pypi.org/)
 - ⚡️ Task running with [Poe the Poet](https://github.com/nat-n/poethepoet)
-- ✍️ Code formatting with [Absolufy-imports](https://github.com/MarcoGorelli/absolufy-imports), [Black](https://github.com/psf/black), and [Ruff](https://github.com/charliermarsh/ruff)
+- ✍️ Code formatting with [Black](https://github.com/psf/black) and [Ruff](https://github.com/charliermarsh/ruff)
 - ✅ Code linting with [Pre-commit](https://pre-commit.com/), [Mypy](https://github.com/python/mypy), and [Ruff](https://github.com/charliermarsh/ruff)
 - 🏷 Optionally follows the [Conventional Commits](https://www.conventionalcommits.org/) standard to automate [Semantic Versioning](https://semver.org/) and [Keep A Changelog](https://keepachangelog.com/) with [Commitizen](https://github.com/commitizen-tools/commitizen)
 - 💌 Verified commits with [GPG](https://gnupg.org/)

--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -56,16 +56,10 @@ repos:
         language: system
         stages: [commit-msg]
       {%- endif %}
-      - id: absolufy-imports
-        name: absolufy-imports
-        entry: absolufy-imports
-        require_serial: true
-        language: system
-        types: [python]
       - id: ruff
         name: ruff
         entry: ruff
-        args: ["--fixable=ALL,{% if cookiecutter.development_environment == "strict" %}ERA001,F401,F841,T201,T203{% else %}F401,F841{% endif %}"{% if cookiecutter.development_environment == "simple" %}, "--fix-only"{% endif %}]
+        args: ["--extend-fixable={% if cookiecutter.development_environment == "strict" %}ERA001,F401,F841,T201,T203{% else %}F401,F841{% endif %}"{% if cookiecutter.development_environment == "simple" %}, "--fix-only"{% endif %}]
         require_serial: true
         language: system
         types: [python]

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -51,7 +51,6 @@ uvicorn = { extras = ["standard"], version = ">=0.20.0" }
 {%- endif %}
 
 [tool.poetry.group.test.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
-absolufy-imports = ">=0.3.1"
 {%- if cookiecutter.with_jupyter_lab|int %}
 black = { extras = ["jupyter"], version = ">=23.3.0" }
 {%- else %}
@@ -70,7 +69,7 @@ pytest = ">=7.3.1"
 pytest-clarity = ">=1.0.1"
 pytest-mock = ">=3.10.0"
 pytest-xdist = ">=3.2.1"
-ruff = ">=0.0.265"
+ruff = ">=0.0.270"
 {%- if cookiecutter.development_environment == "strict" %}
 safety = ">=2.3.4,!=2.3.5"
 shellcheck-py = ">=0.9.0"
@@ -149,16 +148,24 @@ fix = true
 ignore-init-module-imports = true
 line-length = 100
 {%- if cookiecutter.development_environment == "strict" %}
-select = ["A", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "ERA", "F", "G", "I", "INP", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "S", "SIM", "T10", "T20", "TID", "UP", "W", "YTT"]
+select = ["A", "ASYNC", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "EM", "ERA", "F", "FLY", "G", "I", "ICN", "INP", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "S", "SIM", "SLF", "T10", "T20", "TCH", "TID", "TRY", "UP", "W", "YTT"]
 ignore = ["E501", "PGH001", "RET504", "S101"]
 unfixable = ["ERA001", "F401", "F841", "T201", "T203"]
 {%- else %}
-select = ["A", "B", "C4", "C90", "D", "DTZ", "E", "F", "I", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
+select = ["A", "ASYNC", "B", "C4", "C90", "D", "DTZ", "E", "F", "FLY", "I", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
 ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
 unfixable = ["F401", "F841"]
 {%- endif %}
 src = ["src", "tests"]
 target-version = "py{{ cookiecutter.python_version.split('.')[:2]|join }}"
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+{%- if cookiecutter.development_environment == "strict" %}
+
+[tool.ruff.pycodestyle]
+max-doc-length = 100
+{%- endif %}
 
 [tool.ruff.pydocstyle]
 convention = "{{ cookiecutter.docstring_style|lower }}"


### PR DESCRIPTION
- Removes `absolufy-imports` as [the TID rules include an autofix for this](https://beta.ruff.rs/docs/rules/#flake8-tidy-imports-tid) (closes #150).
- Uses the new `--extend-fixable` to add fixable rules in `poe lint`.
- Adds many new rules to both simple and strict mode.
- Updated configuration of some rules.