### PR TITLE
fix: revert auth.toml path on macOS

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/README.md
+++ b/{{ cookiecutter.__package_name_kebab_case }}/README.md
@@ -84,7 +84,7 @@ _Python application_: to serve this {% if cookiecutter.with_fastapi_api|int %}RE
 1. [Create a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) with the `api` scope and use it to [add your private package repository credentials to your Poetry's `auth.toml` file](https://python-poetry.org/docs/repositories/#configuring-credentials):
     ```toml
     # Linux:   ~/.config/pypoetry/auth.toml
-    # macOS:   ~/Library/Preferences/pypoetry/auth.toml
+    # macOS:   ~/Library/Application Support/pypoetry/auth.toml
     # Windows: C:\Users\%USERNAME%\AppData\Roaming\pypoetry\auth.toml
     [http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]
     username = "{personal access token name}"
@@ -94,7 +94,7 @@ _Python application_: to serve this {% if cookiecutter.with_fastapi_api|int %}RE
 1. [Add your private package repository credentials to your Poetry's `auth.toml` file](https://python-poetry.org/docs/repositories/#configuring-credentials):
     ```toml
     # Linux:   ~/.config/pypoetry/auth.toml
-    # macOS:   ~/Library/Preferences/pypoetry/auth.toml
+    # macOS:   ~/Library/Application Support/pypoetry/auth.toml
     # Windows: C:\Users\%USERNAME%\AppData\Roaming\pypoetry\auth.toml
     [http-basic.{{ cookiecutter.private_package_repository_name|slugify }}]
     username = "{username}"

--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -73,7 +73,7 @@ services:
 
 secrets:
   poetry-auth:
-    file: "${POETRY_AUTH_TOML_PATH:-~/Library/Preferences/pypoetry/auth.toml}"
+    file: "${POETRY_AUTH_TOML_PATH:-~/Library/Application Support/pypoetry/auth.toml}"
 {%- endif %}
 
 volumes:


### PR DESCRIPTION
The path to Poetry's `auth.toml` was changed again [1].

[1] https://github.com/python-poetry/poetry/blob/master/src/poetry/locations.py#L24-L30