### PR TITLE
Add gitlab workflow and gitlens to vscode extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,9 @@
             "extensions": [
                 "ms-python.python",
                 "tamasfe.even-better-toml",
-                "visualstudioexptteam.vscodeintellicode"
+                "visualstudioexptteam.vscodeintellicode",
+                "GitLab.gitlab-workflow",
+                "eamodio.gitlens"
             ],
             "settings": {
                 "editor.formatOnSave": true,


### PR DESCRIPTION
Add [Gitlab](https://marketplace.visualstudio.com/items?itemName=GitLab.gitlab-workflow#ci-variable-autocompletion) and
[Gitlens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) to the vscode extensions installed in the devcontainer.