### PR TITLE
fix: Skip no-commit-to-branch hook in CI

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     {%- if not cookiecutter.private_package_repository_name %}
     environment:
       - POETRY_PYPI_TOKEN_PYPI
+      - CI
     {%- else %}
     secrets:
       - poetry-auth

--- a/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/docker-compose.yml
@@ -16,8 +16,10 @@ services:
         GID: ${GID:-1000}
     {%- if not cookiecutter.private_package_repository_name %}
     environment:
-      - POETRY_PYPI_TOKEN_PYPI
+      {%- if cookiecutter.development_environment == "strict" %}
       - CI
+      {%- endif %}
+      - POETRY_PYPI_TOKEN_PYPI
     {%- else %}
     secrets:
       - poetry-auth

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -275,11 +275,7 @@ convention = "{{ cookiecutter.docstring_style|lower }}"
 
     [[tool.poe.tasks.lint.sequence]]
     shell = """
-{%- if cookiecutter.development_environment == "strict" %}
-      if [ -n "$CI" ]; then
-        export SKIP=no-commit-to-branch
-      fi
-{%- endif %}
+      {%- if cookiecutter.development_environment == "strict" %}[ -n "$CI" ] && export SKIP=no-commit-to-branch{%- endif %}
       pre-commit run --all-files --color always
       """
 {%- if cookiecutter.development_environment == "strict" %}

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -274,10 +274,13 @@ convention = "{{ cookiecutter.docstring_style|lower }}"
   help = "Lint this package"
 
     [[tool.poe.tasks.lint.sequence]]
-    cmd = """
-      pre-commit run
-        --all-files
-        --color always
+    shell = """
+{%- if cookiecutter.development_environment == "strict" %}
+      if [ -n "$CI" ]; then
+        export SKIP=no-commit-to-branch
+      fi
+{%- endif %}
+      pre-commit run --all-files --color always
       """
 {%- if cookiecutter.development_environment == "strict" %}
 


### PR DESCRIPTION
The `no-commit-to-branch` hook fails on merge commits on `main` when using GitHub Actions. That specific hook can be skipped using the `SKIP` environment variable. We can do that in the `poe lint` task definition based on whether we are in CI or not. To know that, we can check for the existence of the `CI` environment variable and if it exists, set `SKIP=no-commit-to-branch` when running `pre-commit`.