### PR TITLE
chore: remove `no-commit-to-branch` hook

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -40,9 +40,6 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: [--pytest-test-first]
-      {%- if cookiecutter.development_environment == "strict" %}
-      - id: no-commit-to-branch
-      {%- endif %}
       - id: trailing-whitespace
         types: [python]
   - repo: local


### PR DESCRIPTION
See PR #207 for the reason behind removing this hook.