### PR TITLE
feat: make private package repos explicit

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -79,9 +79,14 @@ jupyterlab = ">=3.6.3"
 pdoc = ">=13.1.1"
 {%- if cookiecutter.private_package_repository_name %}
 
+[[tool.poetry.source]]
+name = "pypi"
+priority = "default"
+
 [[tool.poetry.source]]  # https://python-poetry.org/docs/repositories/#using-a-private-repository
 name = "{{ cookiecutter.private_package_repository_name|slugify }}"
 url = "{{ cookiecutter.private_package_repository_url }}"
+priority = "explicit"
 {%- endif %}
 
 [tool.coverage.report]  # https://coverage.readthedocs.io/en/latest/config.html#report


### PR DESCRIPTION
This PR adds two changes:

1. Makes PyPI the default package source when adding a private package repo. This is needed because [Poetry warns that this will no longer be the case in a future release](https://python-poetry.org/docs/repositories/#default-package-source).
2. [Makes the private package repo an explicit source](https://python-poetry.org/docs/repositories/#explicit-package-sources), so that you need to mark your dependency with `source = "my-private-package-repo"` to install from the private package repo.