### PR TITLE
chore: update ruff rules

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -147,12 +147,12 @@ target-version = "py{{ cookiecutter.python_version.split('.')[:2]|join }}"
 [tool.ruff.lint]
 ignore-init-module-imports = true
 {%- if cookiecutter.development_environment == "strict" %}
-select = ["A", "ASYNC", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "EM", "ERA", "F", "FBT", "FLY", "FURB", "G", "I", "ICN", "INP", "INT", "ISC", "LOG", "N", "NPY", "PERF", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "S", "SIM", "SLF", "SLOT", "T10", "T20", "TCH", "TID", "TRY", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "RET504", "S101"]
+select = ["A", "ASYNC", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "EM", "ERA", "F", "FBT", "FLY", "FURB", "G", "I", "ICN", "INP", "INT", "ISC", "LOG", "N", "NPY", "PERF", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "Q", "RET", "RSE", "RUF", "S", "SIM", "SLF", "SLOT", "T10", "T20", "TCH", "TID", "TRY", "UP", "W", "YTT"]
+ignore = ["D203", "D213", "E501", "RET504", "S101", "S307"]
 unfixable = ["ERA001", "F401", "F841", "T201", "T203"]
 {%- else %}
-select = ["A", "ASYNC", "B", "C4", "C90", "D", "DTZ", "E", "F", "FLY", "FURB", "I", "ISC", "LOG", "N", "NPY", "PERF", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
+select = ["A", "ASYNC", "B", "C4", "C90", "D", "DTZ", "E", "F", "FLY", "FURB", "I", "ISC", "LOG", "N", "NPY", "PERF", "PGH", "PIE", "PL", "PT", "Q", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
+ignore = ["D203", "D213", "E501", "PGH002", "PGH003", "RET504", "S101", "S307"]
 unfixable = ["F401", "F841"]
 {%- endif %}
 


### PR DESCRIPTION
Changes:
- Replace PGH001 with S307 because [the former has been deprecated in favour of the latter](https://github.com/astral-sh/ruff/issues/7283)
- Ignore D203 [because it is in conflict with D211](https://github.com/PyCQA/pydocstyle/issues/141)
- Ignore D213 [because it is in conflict with D212](https://github.com/PyCQA/pydocstyle/issues/475)
- Replace PLC, PLE, PLR, and PLW with PL
- Add [Q](https://docs.astral.sh/ruff/rules/#flake8-quotes-q)