### PR TITLE
feat: optimize Dependabot config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           path: template
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
@@ -8,15 +8,51 @@ updates:
     commit-message:
       prefix: "ci"
       prefix-development: "ci"
-      include: "scope"
+      include: scope
+    groups:
+       ci-dependencies:
+          patterns:
+            - "*"
+{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: monthly
     commit-message:
-      prefix: "build"
+      prefix: "chore"
       prefix-development: "build"
-      include: "scope"
+      include: scope
+    versioning-strategy: increase
+    allow:
+      - dependency-type: production
+{%- endif %}
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore"
+      prefix-development: "build"
+      include: scope
+    versioning-strategy: increase
+    allow:
+      - dependency-type: development
+    groups:
+       development-dependencies:
+          patterns:
+            - "*"
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore"
+      prefix-development: "build"
+      include: scope
     versioning-strategy: lockfile-only
     allow:
-      - dependency-type: "all"
+      - dependency-type: indirect
+    groups:
+       transitive-dependencies:
+          patterns:
+            - "*"

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
       prefix-development: "ci"
       include: scope
     groups:
-       ci-dependencies:
-          patterns:
-            - "*"
+      ci-dependencies:
+        patterns:
+          - "*"
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   - package-ecosystem: pip
     directory: /
@@ -26,9 +26,9 @@ updates:
     allow:
       - dependency-type: production
     groups:
-       runtime-dependencies:
-          patterns:
-            - "*"
+      runtime-dependencies:
+        patterns:
+          - "*"
 {%- endif %}
   - package-ecosystem: pip
     directory: /
@@ -42,9 +42,9 @@ updates:
     allow:
       - dependency-type: development
     groups:
-       development-dependencies:
-          patterns:
-            - "*"
+      development-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: pip
     directory: /
     schedule:
@@ -57,6 +57,6 @@ updates:
     allow:
       - dependency-type: indirect
     groups:
-       transitive-dependencies:
-          patterns:
-            - "*"
+      transitive-dependencies:
+        patterns:
+          - "*"

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
     versioning-strategy: increase
     allow:
       - dependency-type: production
+    groups:
+       runtime-dependencies:
+          patterns:
+            - "*"
 {%- endif %}
   - package-ecosystem: pip
     directory: /

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
       ci-dependencies:
         patterns:
           - "*"
-{%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int or cookiecutter.with_typer_cli|int %}
   - package-ecosystem: pip
     directory: /
     schedule:
@@ -22,41 +21,16 @@ updates:
       prefix: "chore"
       prefix-development: "build"
       include: scope
-    versioning-strategy: increase
     allow:
+      {%- if cookiecutter.project_type == "app" %}
       - dependency-type: production
-    groups:
-      runtime-dependencies:
-        patterns:
-          - "*"
-{%- endif %}
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: monthly
-    commit-message:
-      prefix: "chore"
-      prefix-development: "build"
-      include: scope
-    versioning-strategy: increase
-    allow:
+      {%- endif %}
       - dependency-type: development
+    versioning-strategy: increase
     groups:
+      {%- if cookiecutter.project_type == "app" %}
+      runtime-dependencies:
+        dependency-type: production
+      {%- endif %}
       development-dependencies:
-        patterns:
-          - "*"
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: monthly
-    commit-message:
-      prefix: "chore"
-      prefix-development: "build"
-      include: scope
-    versioning-strategy: lockfile-only
-    allow:
-      - dependency-type: indirect
-    groups:
-      transitive-dependencies:
-        patterns:
-          - "*"
+        dependency-type: development

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "{{ cookiecutter.python_version }}"
 

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
@@ -42,6 +42,6 @@ jobs:
         run: devcontainer exec --workspace-folder . poe test
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: reports/coverage.xml


### PR DESCRIPTION
Before this PR: the Dependabot configuration is suboptimal because it doesn't differentiate well between applications and packages, and because it doesn't group updates to reduce the number of PRs.

After this PR:
- For Python applications and packages:
  - Every month, Dependabot will create *a single* PR for all direct development dependency updates. This PR will bump the minimum version of these dependencies in `pyproject.toml`.
  - ~~Every month, Dependabot will create *a single* PR for all transitive dependency updates (of both production & development dependencies). This PR only updates the lockfile.~~
- For Python applications:
  - Every month, Dependabot will create *a single*  PR for all direct production dependency updates. This PR will bump the minimum version of these dependencies in `pyproject.toml`.
- For GitHub Actions:
  - The current CI dependencies are updated to the latest versions.
  - Dependabot will create *a single* PR for all CI dependency updates per month.

EDIT: Dependabot unfortunately has a number of limitations currently that prevent us from grouping transitive dependency updates and using a different versioning strategy for them. I've updated the scope of this PR's changes above.