### PR TITLE
feat: add ipywidgets to dev dependencies

### DIFF
--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -63,6 +63,7 @@ typeguard = ">=4.2.1"
 [tool.poetry.group.dev.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
 cruft = ">=2.15.0"
 ipykernel = ">=6.29.4"
+ipywidgets = ">=8.1.2"
 pdoc = ">=14.4.0"
 {%- if cookiecutter.private_package_repository_name %}
 


### PR DESCRIPTION
It's generally useful to be have ipywidgets when creating notebooks in VS Code.